### PR TITLE
Improve graf-homer-hep-prom

### DIFF
--- a/docker/graf-homer-hep-prom/README.md
+++ b/docker/graf-homer-hep-prom/README.md
@@ -8,7 +8,7 @@ Run from this folder
 To bring up  
 
 * adminer localhost:8080 (root/) empty password
-* homer localhost:80 (admin/test123) 
+* homer localhost:9080 (admin/test123) 
 * prometheus localhost:9090 (admin/admin)
 * grafana localhost:3000 (admin/admin)
  

--- a/docker/graf-homer-hep-prom/caddy/Caddyfile
+++ b/docker/graf-homer-hep-prom/caddy/Caddyfile
@@ -27,3 +27,12 @@
     errors stderr
     tls off
 }
+
+:80 {
+    proxy / homer-webapp:80 {
+            transparent
+        }
+
+    errors stderr
+    tls off
+}

--- a/docker/graf-homer-hep-prom/caddy/Caddyfile
+++ b/docker/graf-homer-hep-prom/caddy/Caddyfile
@@ -28,7 +28,7 @@
     tls off
 }
 
-:80 {
+:9080 {
     proxy / homer-webapp:80 {
             transparent
         }

--- a/docker/graf-homer-hep-prom/docker-compose.yml
+++ b/docker/graf-homer-hep-prom/docker-compose.yml
@@ -165,8 +165,8 @@ services:
       - "DB_HOST=db"
       - "DB_USER=homer_user"
       - "DB_PASS=homer_password"
-    ports:
-      - "80:80"
+    expose:
+      - 80
     volumes:
       - ./docker-compose.yml:/homer-semaphore/.bootstrapped
     networks:

--- a/docker/graf-homer-hep-prom/docker-compose.yml
+++ b/docker/graf-homer-hep-prom/docker-compose.yml
@@ -95,6 +95,7 @@ services:
       - "3000:3000"
       - "9090:9090"
       - "9093:9093"
+      - "80:80"
     volumes:
       - ./caddy/:/etc/caddy/
     environment:

--- a/docker/graf-homer-hep-prom/docker-compose.yml
+++ b/docker/graf-homer-hep-prom/docker-compose.yml
@@ -164,8 +164,8 @@ services:
     image: sipcapture/homer-webapp
     environment:
       - "DB_HOST=db"
-      - "DB_USER=homer_user"
-      - "DB_PASS=homer_password"
+      - "DB_USER=root"
+      - "DB_PASS="
     expose:
       - 80
     volumes:

--- a/docker/graf-homer-hep-prom/docker-compose.yml
+++ b/docker/graf-homer-hep-prom/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - "3000:3000"
       - "9090:9090"
       - "9093:9093"
-      - "80:80"
+      - "9080:9080"
     volumes:
       - ./caddy/:/etc/caddy/
     environment:


### PR DESCRIPTION
Correcting db auth mismatch, and shielding the homer-webapp behind caddy proxy like the other components for consistency