### PR TITLE
Fixed DBRotate to not try and run if there is no DB set

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -144,13 +144,13 @@ func (h *HEPInput) Run() {
 		defer l.End()
 	}
 
-	if config.Setting.DBRotate {
-		r := rotator.Setup(h.quit)
-		r.Rotate()
-		defer r.End()
-	}
 
 	if h.useDB {
+		if config.Setting.DBRotate {
+			r := rotator.Setup(h.quit)
+			r.Rotate()
+			defer r.End()
+		}
 		d := database.New(config.Setting.DBDriver)
 		d.Chan = h.dbCh
 


### PR DESCRIPTION
If you are not using a database, the rotator constantly logs `ERR dial tcp 127.0.0.1:3306: connect: connection refused`.  DBRotate should not be setup/initialized if there is no DBAddr setup.