### PR TITLE
Add ESUser and ESPass for elasticSearch auth

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,8 @@ type HeplifyServer struct {
 	HEPTLSAddr         string   `default:"0.0.0.0:9060"`
 	ESAddr             string   `default:""`
 	ESDiscovery        bool     `default:"true"`
+	ESUser             string   `default""`
+	ESPass             string   `default""`
 	MQDriver           string   `default:""`
 	MQAddr             string   `default:""`
 	MQTopic            string   `default:""`

--- a/config/webconfig.go
+++ b/config/webconfig.go
@@ -17,6 +17,17 @@ func WebConfig(r *http.Request) (*HeplifyServer, error) {
 	webSetting.HEPTCPAddr = r.FormValue("HEPTCPAddr")
 	webSetting.HEPTLSAddr = r.FormValue("HEPTLSAddr")
 	webSetting.ESAddr = r.FormValue("ESAddr")
+	webSetting.ESUser = r.FormValue("ESUser")
+	ESPass := r.FormValue("ESPass")
+	if ESPass != "*******" {
+		webSetting.ESPass = ESPass
+	}
+	ESDiscovery := r.FormValue("ESDiscovery")
+	if ESDiscovery == "true" {
+		webSetting.ESDiscovery = true
+	} else if ESDiscovery == "false" {
+		webSetting.ESDiscovery = false
+	}
 	webSetting.LokiURL = r.FormValue("LokiURL")
 	if webSetting.LokiBulk, err = strconv.Atoi(r.FormValue("LokiBulk")); err != nil {
 		return nil, err
@@ -174,6 +185,22 @@ var WebForm = `
 		<div>
 			<label>ESAddr</label>
 			<input  type="text" name="ESAddr" placeholder="{{.ESAddr}}" value="{{.ESAddr}}">
+		</div>
+		<div>
+			<label>ESUser</label>
+			<input  type="text" name="ESUser" placeholder="{{.ESUser}}" value="{{.ESUser}}">
+		</div>
+		<div>
+			<label>ESPass</label>
+			<input  type="text" name="ESPass" placeholder="*******" value="*******">
+		</div>
+		<div>
+			<label>ESDiscovery</label>
+			<select name="ESDiscovery">
+				<option value="">-- Please choose ({{.ESDiscovery}}) --</option>
+				<option value="true">true</option>
+				<option value="false">false</option>
+			</select>
 		</div>
 		<div>
 			<label>LokiURL</label>

--- a/remotelog/elasticsearch.go
+++ b/remotelog/elasticsearch.go
@@ -22,10 +22,18 @@ type Elasticsearch struct {
 func (e *Elasticsearch) setup() error {
 	var err error
 	e.ctx = context.Background()
-	e.client, err = elastic.NewClient(
-		elastic.SetURL(config.Setting.ESAddr),
-		elastic.SetSniff(config.Setting.ESDiscovery),
-	)
+	if len(config.Setting.ESUser) > 0 {
+		e.client, err = elastic.NewClient(
+			elastic.SetURL(config.Setting.ESAddr),
+			elastic.SetSniff(config.Setting.ESDiscovery),
+			elastic.SetBasicAuth(config.Setting.ESUser, config.Setting.ESPass),
+		)
+	} else {
+		e.client, err = elastic.NewClient(
+			elastic.SetURL(config.Setting.ESAddr),
+			elastic.SetSniff(config.Setting.ESDiscovery),
+		)
+	}
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -144,7 +144,7 @@ func (h *HEPInput) Run() {
 		defer l.End()
 	}
 
-	if config.Setting.DBRotate {
+	if h.useDB && config.Setting.DBRotate {
 		r := rotator.Setup(h.quit)
 		r.Rotate()
 		defer r.End()


### PR DESCRIPTION
ElasticSearch API can support auth, This change allows a user to set the user/pass needed for that.