### PR TITLE
HEP.parseSIP: better handling of CID and AlegIDs

### DIFF
--- a/decoder/sip.go
+++ b/decoder/sip.go
@@ -21,9 +21,11 @@ func (h *HEP) parseSIP() error {
 	}
 
 	if h.CID == "" {
-		h.CID = h.SIP.CallID
-	} else if h.SIP.XCallID != "" {
-		h.CID = h.SIP.XCallID
+		if h.SIP.XCallID != "" {
+			h.CID = h.SIP.XCallID
+		} else {
+			h.CID = h.SIP.CallID
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The code that was there doesn't seem to work as intended. This new code will keep the HEP borne CID intact, and if absent use AlegIDs, finally falling back to using the SIP Call-ID.