### PR TITLE
Restore desired behaviour for CID field

### DIFF
--- a/decoder/sip.go
+++ b/decoder/sip.go
@@ -21,11 +21,9 @@ func (h *HEP) parseSIP() error {
 	}
 
 	if h.CID == "" {
-		if h.SIP.XCallID != "" {
-			h.CID = h.SIP.XCallID
-		} else {
-			h.CID = h.SIP.CallID
-		}
+		h.CID = h.SIP.CallID
+	} else if h.SIP.XCallID != "" {
+		h.CID = h.SIP.XCallID
 	}
 
 	return nil


### PR DESCRIPTION
This PR reverts https://github.com/sipcapture/heplify-server/commit/410fa40c65cf7510a5679f434befcf55ab602b4e which needs to be discussed and addressed in more depth to avoid impairing existing logic and mechanism. The XCID field is not meant to overwrite the SIP CallID to avoid concealing the original identifier permanently, but rather used as `correlation_id` (corrID` in heplify-server) to allow the system finding matching sessions. With this patch, the original Session ID becomes invisible with the exception of the expensive full-text search against all SIP methods.