### PR TITLE
remove all too old tables, not only one day

### DIFF
--- a/rotator/mariafiles.go
+++ b/rotator/mariafiles.go
@@ -1,12 +1,21 @@
 package rotator
 
 var (
-	droplogmaria      = []string{"DROP TABLE logs_capture_all_{{date}};"}
-	dropreportmaria   = []string{"DROP TABLE report_capture_all_{{date}};"}
-	droprtcpmaria     = []string{"DROP TABLE rtcp_capture_all_{{date}};"}
-	dropcallmaria     = []string{"DROP TABLE sip_capture_call_{{date}};"}
-	dropregistermaria = []string{"DROP TABLE sip_capture_registration_{{date}};"}
-	dropdefaultmaria  = []string{"DROP TABLE sip_capture_rest_{{date}};"}
+	listdroplogmaria      = []string{"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE 'logs_capture_all_%' and TABLE_NAME < 'logs_capture_all_{{date}}';"}
+	listdropreportmaria   = []string{"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE 'report_capture_all_%' and TABLE_NAME < 'report_capture_all_{{date}}';"}
+	listdroprtcpmaria     = []string{"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE 'rtcp_capture_all_%' and TABLE_NAME < 'rtcp_capture_all_{{date}}';"}
+	listdropcallmaria     = []string{"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE 'sip_capture_call_%' and TABLE_NAME < 'sip_capture_call_{{date}}';"}
+	listdropregistermaria = []string{"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE 'sip_capture_registration_%' and TABLE_NAME < 'sip_capture_registration_{{date}}';"}
+	listdropdefaultmaria  = []string{"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE 'sip_capture_rest_%' and TABLE_NAME < 'sip_capture_rest_{{date}}';"}
+)
+
+var (
+	droplogmaria      = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropreportmaria   = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	droprtcpmaria     = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropcallmaria     = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropregistermaria = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropdefaultmaria  = []string{"DROP TABLE IF EXISTS {{partName}};"}
 )
 
 var insconfmaria = []string{

--- a/rotator/pgfiles.go
+++ b/rotator/pgfiles.go
@@ -1,13 +1,23 @@
 package rotator
 
 var (
-	droplogpg      = []string{"DROP TABLE hep_proto_100_default_{{date}}_{{time}};"}
-	dropreportpg   = []string{"DROP TABLE hep_proto_35_default_{{date}}_{{time}};"}
-	dropisuppg     = []string{"DROP TABLE hep_proto_54_default_{{date}}_{{time}};"}
-	droprtcppg     = []string{"DROP TABLE hep_proto_5_default_{{date}}_{{time}};"}
-	dropcallpg     = []string{"DROP TABLE hep_proto_1_call_{{date}}_{{time}};"}
-	dropregisterpg = []string{"DROP TABLE hep_proto_1_registration_{{date}}_{{time}};"}
-	dropdefaultpg  = []string{"DROP TABLE hep_proto_1_default_{{date}}_{{time}};"}
+	listdroplogpg      = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_100_default_%' and tablename < 'hep_proto_100_default_{{date}}_{{time}}';"}
+	listdropreportpg   = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_35_default_%' and tablename < 'hep_proto_35_default_{{date}}_{{time}}';"}
+	listdropisuppg     = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_54_default_%' and tablename < 'hep_proto_54_default_{{date}}_{{time}}';"}
+	listdroprtcppg     = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_5_default_%' and tablename < 'hep_proto_5_default_{{date}}_{{time}}';"}
+	listdropcallpg     = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_1_call_%' and tablename < 'hep_proto_1_call_{{date}}_{{time}}';"}
+	listdropregisterpg = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_1_registration_%' and tablename < 'hep_proto_1_registration_{{date}}_{{time}}';"}
+	listdropdefaultpg  = []string{"SELECT tablename FROM pg_tables WHERE tablename LIKE 'hep_proto_1_default_%' and tablename < 'hep_proto_1_default_{{date}}_{{time}}';"}
+)
+
+var (
+	droplogpg      = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropreportpg   = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropisuppg     = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	droprtcppg     = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropcallpg     = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropregisterpg = []string{"DROP TABLE IF EXISTS {{partName}};"}
+	dropdefaultpg  = []string{"DROP TABLE IF EXISTS {{partName}};"}
 )
 
 var idxconfpg = []string{

--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -19,6 +19,7 @@ const (
 	partitionMinTime   = "{{minTime}}"
 	partitionStartTime = "{{startTime}}"
 	partitionEndTime   = "{{endTime}}"
+	partitionName      = "{{partName}}"
 )
 
 type Rotator struct {
@@ -181,28 +182,62 @@ func (r *Rotator) CreateConfTables(duration int) (err error) {
 }
 
 func (r *Rotator) DropTables() (err error) {
+	logp.Debug("rotator", "start drop tables (%v)\n", time.Now())
 	db, err := sql.Open(r.driver, r.dataDBAddr)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 	if r.driver == "mysql" {
-		r.dbExecFile(db, droplogmaria, replaceDay(r.dropDays*-1), 0, 0)
-		r.dbExecFile(db, dropreportmaria, replaceDay(r.dropDays*-1), 0, 0)
-		r.dbExecFile(db, droprtcpmaria, replaceDay(r.dropDays*-1), 0, 0)
-		r.dbExecFile(db, dropcallmaria, replaceDay(r.dropDaysCall*-1), 0, 0)
-		r.dbExecFile(db, dropregistermaria, replaceDay(r.dropDaysRegister*-1), 0, 0)
-		r.dbExecFile(db, dropdefaultmaria, replaceDay(r.dropDaysDefault*-1), 0, 0)
+		r.dbExecDropTables(db, listdroplogmaria, droplogmaria, r.dropDays)
+		r.dbExecDropTables(db, listdropreportmaria, dropreportmaria, r.dropDays)
+		r.dbExecDropTables(db, listdroprtcpmaria, droprtcpmaria, r.dropDays)
+		r.dbExecDropTables(db, listdropcallmaria, dropcallmaria, r.dropDaysCall)
+		r.dbExecDropTables(db, listdropregistermaria, dropregistermaria, r.dropDaysRegister)
+		r.dbExecDropTables(db, listdropdefaultmaria, dropdefaultmaria, r.dropDaysDefault)
 	} else if r.driver == "postgres" {
-		r.dbExecFileLoop(db, droplogpg, replaceDay(r.dropDays*-1), r.dropDays, r.partLog)
-		r.dbExecFileLoop(db, dropisuppg, replaceDay(r.dropDays*-1), r.dropDays, r.partIsup)
-		r.dbExecFileLoop(db, dropreportpg, replaceDay(r.dropDays*-1), r.dropDays, r.partQos)
-		r.dbExecFileLoop(db, droprtcppg, replaceDay(r.dropDays*-1), r.dropDays, r.partQos)
-		r.dbExecFileLoop(db, dropcallpg, replaceDay(r.dropDaysCall*-1), r.dropDaysCall, r.partSip)
-		r.dbExecFileLoop(db, dropregisterpg, replaceDay(r.dropDaysRegister*-1), r.dropDaysRegister, r.partSip)
-		r.dbExecFileLoop(db, dropdefaultpg, replaceDay(r.dropDaysDefault*-1), r.dropDaysDefault, r.partSip)
+		r.dbExecDropTables(db, listdroplogpg, droplogpg, r.dropDays)
+		r.dbExecDropTables(db, listdropisuppg, dropisuppg, r.dropDays)
+		r.dbExecDropTables(db, listdropreportpg, dropreportpg, r.dropDays)
+		r.dbExecDropTables(db, listdroprtcppg, droprtcppg, r.dropDays)
+		r.dbExecDropTables(db, listdropcallpg, dropcallpg, r.dropDaysCall)
+		r.dbExecDropTables(db, listdropregisterpg, dropregisterpg, r.dropDaysRegister)
+		r.dbExecDropTables(db, listdropdefaultpg, dropdefaultpg, r.dropDaysDefault)
 	}
+	logp.Debug("rotator", "finished drop tables (%v)\n", time.Now())
 	return nil
+}
+
+func (r *Rotator) dbExecDropTables(db * sql.DB, listfile []string, dropfile []string, d int) error {
+	t := time.Now().Add(time.Hour * time.Duration(-24*(d-1)))
+	t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+        partDate := t.Format("20060102")
+	partTime := t.Format("1504")
+        var rows *sql.Rows
+        var lastErr error
+	for _, listquery := range listfile {
+		listquery = strings.Replace(listquery, partitionDate, partDate, -1)
+		listquery = strings.Replace(listquery, partitionTime, partTime, -1)
+		rows, lastErr = db.Query(listquery)
+		if !checkDBErr(lastErr) {
+			for rows.Next() {
+				var partName string
+				lastErr = rows.Scan(&partName)
+				if !checkDBErr(lastErr) {
+					for _, dropquery := range dropfile {
+						dropquery = strings.Replace(dropquery, partitionName, partName, -1)
+		                                logp.Debug("rotator", "db query:\n%s\n\n", dropquery)
+						_, lastErr = db.Exec(dropquery)
+						if checkDBErr(lastErr) {
+							break;
+						}
+					}
+				}
+			}
+			rows.Close()
+		}
+	}
+	return lastErr
 }
 
 func (r *Rotator) dbExec(db *sql.DB, query string) {
@@ -355,7 +390,7 @@ func setStep(name string) (step int) {
 	return
 }
 
-func checkDBErr(err error) {
+func checkDBErr(err error) bool {
 	if err != nil {
 		if mErr, ok := err.(*mysql.MySQLError); ok && (mErr.Number == 1050 ||
 			mErr.Number == 1062 || mErr.Number == 1481 || mErr.Number == 1517) {
@@ -363,5 +398,8 @@ func checkDBErr(err error) {
 		} else {
 			logp.Warn("%s\n\n", err)
 		}
+		return true;
+	} else {
+		return false;
 	}
 }


### PR DESCRIPTION
When the rotator deletes old tables, it only deletes them of the newest no longer needed day. If for some reason the delete can not be done (server not running, database problem, network problem, etc.) the delete will not be tried again.If the retention times are lowered the old tables will not be deleted too.

I changed the rotator so that it will list all too old tables an then deletes the ones it found.

(Previous pull request was #296)