### PR TITLE
add Expires header + allow the use of regex to extract value from XCallID body

### DIFF
--- a/cmd/heplify-server/heplify-server.go
+++ b/cmd/heplify-server/heplify-server.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"regexp"
 
 	_ "net/http/pprof"
 
@@ -46,21 +45,7 @@ func init() {
 		fmt.Println("Could not find toml config file, use flag defaults.", err)
 	}
 	
-	
-	if len(config.Setting.AlegIDs) > 0 {
-		//rexStore := config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
-		//config.CompileStore = *rexStore
-		config.CompileStore = config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
-		
-		for i := range config.Setting.AlegIDs {
-			AlegSplit := strings.Split(config.Setting.AlegIDs[i], ",")
-			//assigned back the AlegIDs without the regex
-			config.Setting.AlegIDs[i] = AlegSplit[0]
-			if len(AlegSplit) > 1 {
-				config.CompileStore.RegexMap[AlegSplit[0]] = regexp.MustCompile(AlegSplit[1])
-			}
-		}
-	}
+	config.Setting.AlegIDs = config.GenerateRegexMap(config.Setting.AlegIDs)
 
 	logp.DebugSelectorsStr = &config.Setting.LogDbg
 	logp.ToStderr = &config.Setting.LogStd

--- a/cmd/heplify-server/heplify-server.go
+++ b/cmd/heplify-server/heplify-server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"regexp"
 
 	_ "net/http/pprof"
 
@@ -43,6 +44,22 @@ func init() {
 		}
 	} else {
 		fmt.Println("Could not find toml config file, use flag defaults.", err)
+	}
+	
+	
+	if len(config.Setting.AlegIDs) > 0 {
+		//rexStore := config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
+		//config.CompileStore = *rexStore
+		config.CompileStore = config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
+		
+		for i := range config.Setting.AlegIDs {
+			AlegSplit := strings.Split(config.Setting.AlegIDs[i], ",")
+			//assigned back the AlegIDs without the regex
+			config.Setting.AlegIDs[i] = AlegSplit[0]
+			if len(AlegSplit) > 1 {
+				config.CompileStore.RegexMap[AlegSplit[0]] = regexp.MustCompile(AlegSplit[1])
+			}
+		}
 	}
 
 	logp.DebugSelectorsStr = &config.Setting.LogDbg

--- a/config/regexstore.go
+++ b/config/regexstore.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"regexp"
+)
+
+var CompileStore RegexData
+
+type RegexData struct {
+	RegexMap            map[string]*regexp.Regexp
+}

--- a/config/regexstore.go
+++ b/config/regexstore.go
@@ -2,10 +2,28 @@ package config
 
 import (
 	"regexp"
+	"strings"
 )
 
 var CompileStore RegexData
 
 type RegexData struct {
 	RegexMap            map[string]*regexp.Regexp
+}
+
+
+func GenerateRegexMap(AlegIDs []string) []string{
+	if len(AlegIDs) > 0 {
+		CompileStore = RegexData{RegexMap: make(map[string]*regexp.Regexp)}
+		
+		for i := range AlegIDs {
+			AlegSplit := strings.Split(AlegIDs[i], ",")
+			//assigned back the AlegIDs without the regex
+			AlegIDs[i] = AlegSplit[0]
+			if len(AlegSplit) > 1 {
+				CompileStore.RegexMap[AlegSplit[0]] = regexp.MustCompile(AlegSplit[1])
+			}
+		}
+	}
+	return AlegIDs
 }

--- a/example/homer5_config/heplify-server.toml
+++ b/example/homer5_config/heplify-server.toml
@@ -51,7 +51,7 @@ ConfigHTTPAddr        = ""
 # PromAddr        = "0.0.0.0:8899"
 # PromTargetIP    = "10.1.2.111,10.1.2.4,10.1.2.5,10.1.2.6,10.12.44.222"
 # PromTargetName  = "sbc_access,sbc_core,kamailio,asterisk,pstn_gateway"
-# AlegIDs         = ["X-CID","P-Charging-Vector","X-BroadWorks-Correlation-Info"]
+# AlegIDs         = ["X-CID","P-Charging-Vector,icid-value=\"?(.*?)(?:\"|;|$)","X-BroadWorks-Correlation-Info"]
 # DiscardMethod   = ["OPTIONS","NOTIFY"]
 # LogDbg          = "hep,sql"
 # LogLvl          = "warning"

--- a/example/homer7_config/heplify-server.toml
+++ b/example/homer7_config/heplify-server.toml
@@ -54,7 +54,7 @@ ConfigHTTPAddr        = ""
 # PromAddr        = "0.0.0.0:8899"
 # PromTargetIP    = "10.1.2.111,10.1.2.4,10.1.2.5,10.1.2.6,10.12.44.222"
 # PromTargetName  = "sbc_access,sbc_core,kamailio,asterisk,pstn_gateway"
-# AlegIDs         = ["X-CID","P-Charging-Vector","X-BroadWorks-Correlation-Info"]
+# AlegIDs         = ["X-CID","P-Charging-Vector,icid-value=\"?(.*?)(?:\"|;|$)","X-BroadWorks-Correlation-Info"]
 # DiscardMethod   = ["OPTIONS","NOTIFY"]
 # CustomHeader    = ["X-CustomerIP","X-Billing"]
 # SIPHeader      = ["callid","method","ruri_user","ruri_domain","from_user","from_domain","from_tag","to_user","to_domain","to_tag","via","contact_user"]

--- a/sipparser/parser.go
+++ b/sipparser/parser.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"regexp"
 	
 	"github.com/sipcapture/heplify-server/config"
 )
@@ -255,9 +254,7 @@ func (s *SipMsg) addHdr(str string) {
 			if len(s.XHeader) > 0 {
 				for i := range s.XHeader {
 					if s.hdr == s.XHeader[i] {
-						var filter *regexp.Regexp
-						var ok bool
-						filter, ok = config.CompileStore.RegexMap[s.XHeader[i]]
+						filter, ok := config.CompileStore.RegexMap[s.XHeader[i]]
 						if ok {
 							if filter.MatchString(s.hdrv){
 								s.XCallID = filter.FindStringSubmatch(s.hdrv)[1]

--- a/sipparser/parser.go
+++ b/sipparser/parser.go
@@ -258,8 +258,6 @@ func (s *SipMsg) addHdr(str string) {
 						if ok {
 							if filter.MatchString(s.hdrv){
 								s.XCallID = filter.FindStringSubmatch(s.hdrv)[1]
-							} else {
-								s.XCallID = "ERR: "+s.hdrv
 							}
 						} else {
 							s.XCallID = s.hdrv

--- a/sipparser/parser_test.go
+++ b/sipparser/parser_test.go
@@ -11,8 +11,6 @@ import (
 	//"fmt"
 	"testing"
 	"github.com/sipcapture/heplify-server/config"
-	"strings"
-	"regexp"
 )
 
 var testInviteMsg = "INVITE sip:15554440000@X.X.X.X:5060;user=phone SIP/2.0\r\nVia: SIP/2.0/UDP X.X.X.X:5060;branch=z9hG4bK34133a599ll241207INV21d7d0684e84a2d2\r\nMax-Forwards: 35\r\nContact: <sip:X.X.X.X:5060>\r\nTo: <sip:15554440000@X.X.X.X;user=phone;noa=national>\r\nFrom: \"Unavailable\"<sip:X.X.X.X;user=phone;noa=national>;tag=21d7d068-co2149-FOOI003\r\nCall-ID: 1393184968_47390262@domain.com\r\nCSeq: 214901 INVITE\r\nAuthorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\", algorithm=MD5, uri=\"sip:foo.bar.com\", nonce=\"4f6d7a1d\", response=\"6a79a5c75572b0f6a18963ae04e971cf\", opaque=\"\"\r\nAllow: INVITE,ACK,CANCEL,BYE,REFER,OPTIONS,NOTIFY,SUBSCRIBE,PRACK,INFO\r\nContent-Type: application/sdp\r\nDate: Thu, 29 Sep 2011 16:54:42 GMT\r\nUser-Agent: FAKE-UA-DATA\r\nP-Asserted-Identity: \"Unavailable\"<sip:Restricted@X.X.X.X:5060>\r\nContent-Length: 322\r\n\r\nv=0\r\no=- 567791720 567791720 IN IP4 X.X.X.X\r\ns=FAKE-DATA\r\nc=IN IP4 X.X.X.X\r\nt=0 0\r\nm=audio 17354 RTP/AVP 0 8 86 18 96\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:86 G726-32/8000\r\na=rtpmap:18 G729/8000\r\na=rtpmap:96 telephone-event/8000\r\na=maxptime:20\r\na=fmtp:18 annexb=yes\r\na=fmtp:96 0-15\r\na=sendrecv\r\n"
@@ -132,20 +130,7 @@ func TestParseMsg(t *testing.T) {
 		"Contact: something\r\nAuthorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\"\r\nProxy-Authorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\"\r\n" +
 		"X-RTP-Stat: CS=0;PS=1433;ES=1525;OS=229280;SP=0/0;SO=0;QS=-;PR=1522;ER=1525;OR=243520;CR=0;SR=0;QR=-;PL=0,0;BL=0;LS=0;RB=0/0;SB=-/-;EN=PCMA,FAX;DE=PCMA;JI=23,2;DL=20,20,21;IP=83.138.49.179:7082,102.183.157.163:25132\r\nX-RTP-Stat-Add: DQ=31;DSS=0;DS=0;PLCS=288;JS=1\r\n\r\nv=0\r\no=Dialogic_SDP 1452654 0 IN IP4 0.0.0.0\r\ns=Dialogic-SIP\r\nc=IN IP4 4.71.122.135\r\nt=0 0\r\nm=audio 11676 RTP/AVP 0 101\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:101 telephone-event/8000\r\na=fmtp:101 0-15\r\na=silenceSupp:off - - - -\r\na=ptime:20\r\n"
 	
-	if len(x) > 0 {
-		//rexStore := config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
-		//config.CompileStore = *rexStore
-		config.CompileStore = config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
-		
-		for i := range x {
-			AlegSplit := strings.Split(x[i], ",")
-			//assigned back the AlegIDs without the regex
-			x[i] = AlegSplit[0]
-			if len(AlegSplit) > 1 {
-				config.CompileStore.RegexMap[AlegSplit[0]] = regexp.MustCompile(AlegSplit[1])
-			}
-		}
-	}
+	x = config.GenerateRegexMap(x)
 	
 	s = ParseMsg(m, x, y)
 	//fmt.Println(s.StartLine.Val)

--- a/sipparser/parser_test.go
+++ b/sipparser/parser_test.go
@@ -10,6 +10,9 @@ import (
 	//"fmt"
 	//"fmt"
 	"testing"
+	"github.com/sipcapture/heplify-server/config"
+	"strings"
+	"regexp"
 )
 
 var testInviteMsg = "INVITE sip:15554440000@X.X.X.X:5060;user=phone SIP/2.0\r\nVia: SIP/2.0/UDP X.X.X.X:5060;branch=z9hG4bK34133a599ll241207INV21d7d0684e84a2d2\r\nMax-Forwards: 35\r\nContact: <sip:X.X.X.X:5060>\r\nTo: <sip:15554440000@X.X.X.X;user=phone;noa=national>\r\nFrom: \"Unavailable\"<sip:X.X.X.X;user=phone;noa=national>;tag=21d7d068-co2149-FOOI003\r\nCall-ID: 1393184968_47390262@domain.com\r\nCSeq: 214901 INVITE\r\nAuthorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\", algorithm=MD5, uri=\"sip:foo.bar.com\", nonce=\"4f6d7a1d\", response=\"6a79a5c75572b0f6a18963ae04e971cf\", opaque=\"\"\r\nAllow: INVITE,ACK,CANCEL,BYE,REFER,OPTIONS,NOTIFY,SUBSCRIBE,PRACK,INFO\r\nContent-Type: application/sdp\r\nDate: Thu, 29 Sep 2011 16:54:42 GMT\r\nUser-Agent: FAKE-UA-DATA\r\nP-Asserted-Identity: \"Unavailable\"<sip:Restricted@X.X.X.X:5060>\r\nContent-Length: 322\r\n\r\nv=0\r\no=- 567791720 567791720 IN IP4 X.X.X.X\r\ns=FAKE-DATA\r\nc=IN IP4 X.X.X.X\r\nt=0 0\r\nm=audio 17354 RTP/AVP 0 8 86 18 96\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:86 G726-32/8000\r\na=rtpmap:18 G729/8000\r\na=rtpmap:96 telephone-event/8000\r\na=maxptime:20\r\na=fmtp:18 annexb=yes\r\na=fmtp:96 0-15\r\na=sendrecv\r\n"
@@ -121,6 +124,39 @@ func TestParseMsg(t *testing.T) {
 	}
 	if got, want := s.CustomHeader["X-CUSTOM"], "Avenger"; got != want {
 		t.Errorf("[TestParseMsg] Error parsing msg. X-CUSTOM should be %s. Received: %s", want, got)
+	}
+	
+	x = []string{"X-MEN", "P-Charging-Vector,icid-value=\"(.*)\""}
+	m = "SIP/2.0 200 OK\r\nVia: SIP/2.0/UDP 0.0.0.0:5060;branch=z9hG4bK24477ab511325213INV52e94be64e6687e3;received=0.0.0.0\r\nContact: <sip:10003053258853@0.0.0.0:6060>\r\nTo: <sip:10003053258853@0.0.0.0;user=phone;noa=national>;tag=a94c095b773be1dd6e8d668a785a9c843f6f2cc0\r\nFrom: <sip:8173383772@0.0.0.0;user=phone;noa=national>;tag=52e94be6-co2998-INS002\nCall-ID: 111118149-3524331107-398662@barinfo.fooinfous.com\r\nCSeq: 299801 INVITE\r\nDiversion: something\r\nAccept: application/sdp, application/dtmf-relay, text/plain\r\nUser-Agent: FAKE-UA-DATA\r\nRemote-Party-Id: something\r\nServer: something\r\nX-Nonsense-Hdr: nonsense\r\n" +
+		"Allow: PRACK, INVITE, BYE, REGISTER, ACK, OPTIONS, CANCEL, SUBSCRIBE, NOTIFY, INFO, REFER, UPDATE\r\nContent-Type: application/sdp\r\nServer: Dialogic-SIP/10.5.3.231 IMGDAL0001 0\r\nSupported: 100rel, path, replaces, timer, tdialog\r\nContent-Length: 239\r\nX-FORCE: Deadpool\r\nX-CUSTOM: Avenger\r\nP-Charging-Vector: icid-value=\"somevalue\";orig-ioi=cat.tree.root\r\nP-Asserted-Identity: <sip:8884441111@1.1.1.1:5060;user=phone>\r\nP-Asserted-Identity: <sip:8884442222>\r\n" +
+		"Contact: something\r\nAuthorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\"\r\nProxy-Authorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\"\r\n" +
+		"X-RTP-Stat: CS=0;PS=1433;ES=1525;OS=229280;SP=0/0;SO=0;QS=-;PR=1522;ER=1525;OR=243520;CR=0;SR=0;QR=-;PL=0,0;BL=0;LS=0;RB=0/0;SB=-/-;EN=PCMA,FAX;DE=PCMA;JI=23,2;DL=20,20,21;IP=83.138.49.179:7082,102.183.157.163:25132\r\nX-RTP-Stat-Add: DQ=31;DSS=0;DS=0;PLCS=288;JS=1\r\n\r\nv=0\r\no=Dialogic_SDP 1452654 0 IN IP4 0.0.0.0\r\ns=Dialogic-SIP\r\nc=IN IP4 4.71.122.135\r\nt=0 0\r\nm=audio 11676 RTP/AVP 0 101\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:101 telephone-event/8000\r\na=fmtp:101 0-15\r\na=silenceSupp:off - - - -\r\na=ptime:20\r\n"
+	
+	if len(x) > 0 {
+		//rexStore := config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
+		//config.CompileStore = *rexStore
+		config.CompileStore = config.RegexData{RegexMap: make(map[string]*regexp.Regexp)}
+		
+		for i := range x {
+			AlegSplit := strings.Split(x[i], ",")
+			//assigned back the AlegIDs without the regex
+			x[i] = AlegSplit[0]
+			if len(AlegSplit) > 1 {
+				config.CompileStore.RegexMap[AlegSplit[0]] = regexp.MustCompile(AlegSplit[1])
+			}
+		}
+	}
+	
+	s = ParseMsg(m, x, y)
+	//fmt.Println(s.StartLine.Val)
+	if s.Error != nil {
+		t.Errorf("[TestParseMsg] Error parsing msg. Recevied: %v", s.Error)
+	}
+	if len(s.Body) == 0 {
+		t.Error("[TestParseMsg] Error parsing msg. Body should have a length.")
+	}
+	if got, want := s.XCallID, "somevalue"; got != want {
+		t.Errorf("[TestParseMsg] Error parsing msg. XCallID should be %s. Received: %s", want, got)
 	}
 }
 


### PR DESCRIPTION
Added to extract Expires header from SIP message

XCallID to be able to use regex to further extract correct valid. Example for P-Charging-Vector

P-Charging-Vector: icid-value="somevalue";orig-ioi=host.domain.com

will want to extract "somevalue" instead of the whole string.
Suggested format to add the regex. Regex need to have group construct ( ):
current toml: AlegIDs = ["X-CID","P-Charging-Vector"]
suggested toml: AlegIDs = ["X-CID","P-Charging-Vector,icid-value=\"(.*)\""]


> Could you please rebase it so I can evaluate only the change you need. Currently I don't have that much time to assist here. Another thing that I noticed is that you spilt the Header and compile the regex everytime. Doing it this way is quite slow and slould be improved.

@negbie I have created another PR to fix the messy PR previously so now it only show one commit. Also i have updated the code to try not to compile the regex everytime. do let me know your comments.