### PR TITLE
allow for CallID to be replace with CID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,4 +61,5 @@ type HeplifyServer struct {
 	ScriptFolder       string   `default:""`
 	ScriptHEPFilter    []int    `default:"1,5,100"`
 	TLSCertFolder      string   `default:"."`
+	RCallIDwCID        bool     `default:"false"`
 }

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -142,6 +142,10 @@ func (h *HEP) parse(packet []byte) error {
 				}
 			}
 		}
+		
+		if config.Setting.RCallIDwCID {
+			h.SIP.CallID = h.CID
+		}
 	}
 
 	if h.NodeName == "" {

--- a/example/homer5_config/heplify-server.toml
+++ b/example/homer5_config/heplify-server.toml
@@ -1,4 +1,4 @@
-HEPAddr               = "0.0.0.0:9060"
+HEPAddr               = "0.0.0.0:9070"
 HEPTCPAddr            = ""
 HEPTLSAddr            = "0.0.0.0:9060"
 ESAddr                = ""
@@ -40,6 +40,7 @@ LogStd                = false
 LogSys                = false
 Config                = "./heplify-server.toml"
 ConfigHTTPAddr        = ""
+RCallIDwCID           = false
 
 # Examples:
 # -------------------------------------

--- a/example/homer5_config/heplify-server.toml
+++ b/example/homer5_config/heplify-server.toml
@@ -1,4 +1,4 @@
-HEPAddr               = "0.0.0.0:9070"
+HEPAddr               = "0.0.0.0:9060"
 HEPTCPAddr            = ""
 HEPTLSAddr            = "0.0.0.0:9060"
 ESAddr                = ""

--- a/example/homer7_config/heplify-server.toml
+++ b/example/homer7_config/heplify-server.toml
@@ -44,6 +44,7 @@ LogStd                = false
 LogSys                = false
 Config                = "./heplify-server.toml"
 ConfigHTTPAddr        = ""
+RCallIDwCID           = false
 
 # Examples:
 # -------------------------------------


### PR DESCRIPTION
Correlation for some B2BUA which add prefix to the callID

example:
A ------- callid=ttyyuu@domain.com ----->B2BUA ------ callid:**asbc**ttyyuu@domain.com ----->SIP Server

For correlation, we need to remove the prefix. in the example, we need remove "asbc". We can do this either in heplify, or heplify-server. I have decided to use heplify to do this to reduce work load on heplify-server.

Heplify will modify the callid and save this change on the correlationID(CID) which will then be pass on to heplify-server.
If heplify-server new parameter "RCallIDwCID" is set to **TRUE**, h.SIP.CallID is set to h.CID.

To view the original call-id, you can still check the payload.
