### PR TITLE
Solve issue with HEP packets ignored when length > 8192

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -47,7 +47,7 @@ type HEPStats struct {
 	PktCount uint64
 }
 
-const maxPktLen = 8192
+const maxPktLen = 65507
 
 func NewHEPInput() *HEPInput {
 	h := &HEPInput{


### PR DESCRIPTION
Hello,

Resolves issue #429 .
I change maxPktLen to the max data length for UDP (65507)