### PR TITLE
Add ability to censor request bodies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type HeplifyServer struct {
 	DBDropOnStart      bool     `default:"false"`
 	Dedup              bool     `default:"false"`
 	DiscardMethod      []string `default:""`
+	CensorMethod       []string `default:""`
 	AlegIDs            []string `default:""`
 	ForceALegID        bool     `default:"false"`
 	CustomHeader       []string `default:""`

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -134,6 +134,14 @@ func (h *HEP) parse(packet []byte) error {
 			return err
 		}
 
+		for _, m := range config.Setting.CensorMethod {
+			if m == h.SIP.CseqMethod {
+				lb := len(h.SIP.Body)
+				h.SIP.Body = strings.Repeat("x", lb)
+				h.Payload = h.Payload[:len(h.Payload) - lb] + h.SIP.Body
+			}
+		}
+
 		if len(config.Setting.DiscardMethod) > 0 {
 			for k := range config.Setting.DiscardMethod {
 				if config.Setting.DiscardMethod[k] == h.SIP.CseqMethod {

--- a/server/server.go
+++ b/server/server.go
@@ -88,7 +88,9 @@ func (h *HEPInput) Run() {
 		go h.worker()
 	}
 
-	logp.Info("start %s with %#v\n", config.Version, config.Setting)
+	s := config.Setting
+	s.DBPass = "<private>"
+	logp.Info("start %s with %#v\n", config.Version, s)
 	go h.logStats()
 	go h.reloadWorker()
 


### PR DESCRIPTION
SIP request bodies sometimes contain private information. One example is SMS-over-IP which has text message contents in MESSAGE request bodies.

This adds the ability to selectively replace the request bodies for certain methods with a bunch of x'es.

In addition, heplify-server used to log the database password first thing after the startup, now it doesn't do that anymore.