### PR TITLE
TLSMinVersion configuration, with default TLS1.2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,4 +63,5 @@ type HeplifyServer struct {
 	ScriptFolder       string   `default:""`
 	ScriptHEPFilter    []int    `default:"1,5,100"`
 	TLSCertFolder      string   `default:"."`
+	TLSMinVersion      string   `default:"1.2"`
 }

--- a/server/tls.go
+++ b/server/tls.go
@@ -16,8 +16,10 @@ import (
 func parseTLSVersion(versionText string ) uint16 {
 	switch(versionText){
 	case "1.0":
+		logp.Warn("TLS1.0 is not recommended.  Use 1.2 or greater where possible")
 		return tls.VersionTLS10
 	case "1.1":
+		logp.Warn("TLS1.1 is not recommended.  Use 1.2 or greater where possible")
 		return tls.VersionTLS11
 	case "1.2":
 		return tls.VersionTLS12

--- a/server/tls_test.go
+++ b/server/tls_test.go
@@ -1,0 +1,50 @@
+package input
+
+import (
+	"testing"
+	"crypto/tls"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinVersionConfig_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		output uint16
+	}{
+		{"1.0",tls.VersionTLS10},
+		{"1.1",tls.VersionTLS11},
+		{"1.2",tls.VersionTLS12},
+		{"1.3",tls.VersionTLS13},
+	}
+	for _,test := range(tests) {
+		func(t *testing.T,input string, output uint16) {
+			minVersion := parseTLSVersion(input)
+			assert.Equal(t, minVersion ,output)
+		}(t,test.input,test.output)
+	}
+}
+
+func TestMinVersionConfig_Invalid(t *testing.T) {
+	tests := []struct {
+		input string
+		output uint16
+	}{
+		{"",tls.VersionTLS12},
+		{"10",tls.VersionTLS12},
+		{"11",tls.VersionTLS12},
+		{"12",tls.VersionTLS12},
+		{"13",tls.VersionTLS12},
+		{"a",tls.VersionTLS12},
+		{"A",tls.VersionTLS12},
+		{"TLS1.0",tls.VersionTLS12},
+		{"TLS1.1",tls.VersionTLS12},
+		{"TLS1.2",tls.VersionTLS12},
+		{"TLS1.3",tls.VersionTLS12},
+	}
+	for _,test := range(tests) {
+		func(t *testing.T,input string, output uint16) {
+			minVersion := parseTLSVersion(input)
+			assert.Equal(t, minVersion ,output)
+		}(t,test.input,test.output)
+	}
+}


### PR DESCRIPTION
Result of internal security audit - this change adds a TLSMinVersion configuration option, and sets the default to TLS1.2