### PR TITLE
Added Ability to use SSL Mode for DB Connection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type HeplifyServer struct {
 	DBShema            string   `default:"homer5"`
 	DBDriver           string   `default:"mysql"`
 	DBAddr             string   `default:"localhost:3306"`
+	DBSSLMode          string   `default:"disable"`
 	DBUser             string   `default:"root"`
 	DBPass             string   `default:""`
 	DBDataTable        string   `default:"homer_data"`

--- a/config/webconfig.go
+++ b/config/webconfig.go
@@ -52,6 +52,7 @@ func WebConfig(r *http.Request) (*HeplifyServer, error) {
 		webSetting.DBConfTable = "homer_config"
 	}
 	webSetting.DBAddr = r.FormValue("DBAddr")
+	webSetting.DBAddr = r.FormValue("DBSSLMode")
 	webSetting.DBUser = r.FormValue("DBUser")
 	DBPass := r.FormValue("DBPass")
 	if DBPass != "*******" {
@@ -233,6 +234,10 @@ var WebForm = `
 			<label>DBAddr</label>
 			<input  type="text" name="DBAddr" placeholder="{{.DBAddr}}" value="{{.DBAddr}}">
 		</div>
+		<div>
+		<label>DBSSLMode</label>
+		<input  type="text" name="DBSSLMode" placeholder="{{.DBSSLMode}}" value="{{.DBSSLMode}}">
+	</div>
 		<div>
 			<label>DBUser</label>
 			<input  type="text" name="DBUser" placeholder="{{.DBUser}}" value="{{.DBUser}}">

--- a/database/database.go
+++ b/database/database.go
@@ -107,7 +107,8 @@ func ConnectString(dbName string) (string, error) {
 			addr[0] = addr[1]
 			addr[1] = "''"
 		}
-		dsn = "sslmode=disable connect_timeout=4" +
+		dsn = "sslmode=" + config.Setting.DBSSLMode +
+			" connect_timeout=4" +
 			" host=" + addr[0] +
 			" port=" + addr[1] +
 			" dbname=" + dbName +


### PR DESCRIPTION
This pull request will not cause an issue with prior configurations as it keeps the original variables used in the configuration file for the DB Connection and defaults to disable for SSL mode on the DB connection like before. However, this will allow those like myself that use a DB with SSL to be able to connect to it with Heplify-Server. This is what I'm currently doing with the most recent release tag to connect to my DB backend.