### PR TITLE
Fix GB -> Bytes Conversion

### DIFF
--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -187,7 +187,7 @@ func (r *Rotator) getSizeInBtyes() (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return size * 1024 * 1024, nil
+		return size * 1024 * 1024 * 1024, nil
 	}
 	return 0, errors.New("unsupported disk usage")
 }


### PR DESCRIPTION
Currently, the "conversion" for MB and GB is the same. I believe you need an extra `* 1024` to get the desired results.