### PR TITLE
Fix go vet errors (#473)

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -291,12 +291,13 @@ func WriteJSONString(w io.Writer, s string) (int, error) {
 
 func stb(s string) []byte {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	var res []byte
+
+	bh := (*reflect.SliceHeader)((unsafe.Pointer(&res)))
+	bh.Data = sh.Data
+	bh.Len = sh.Len
+	bh.Cap = sh.Len
+	return res
 }
 
 func toUTF8(s, replacement string) string {

--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -194,6 +194,8 @@ func (r *Rotator) getSizeInBtyes() (float64, error) {
 
 func (r *Rotator) GetDatabaseSize(db *sql.DB, schema string) (float64, error) {
 	var databaseSize string
+	var size float64
+	var err error
 	switch schema {
 	case "maxusage":
 		rows, err := db.Query("select pg_database_size('homer_data');")
@@ -205,7 +207,7 @@ func (r *Rotator) GetDatabaseSize(db *sql.DB, schema string) (float64, error) {
 				return 0, err
 			}
 		}
-		return strconv.ParseFloat(databaseSize, 64)
+		size, err = strconv.ParseFloat(databaseSize, 64)
 	default:
 		rows, err := db.Query("select * from sys_df();")
 		checkDBErr(err)
@@ -216,10 +218,9 @@ func (r *Rotator) GetDatabaseSize(db *sql.DB, schema string) (float64, error) {
 				return 0, err
 			}
 		}
-		percentageUsage, _ := strconv.ParseFloat(strings.TrimSuffix(strings.Split(databaseSize[1:len(databaseSize)-1], ",")[4], "%"), 64)
-		return percentageUsage, nil
+		size, err = strconv.ParseFloat(strings.TrimSuffix(strings.Split(databaseSize[1:len(databaseSize)-1], ",")[4], "%"), 64)
 	}
-	return 0, nil
+	return size, err
 }
 
 func (r *Rotator) UsageProtection(scheme string) error {


### PR DESCRIPTION
Fixes go vet errors:

    # github.com/sipcapture/heplify-server/rotator
    rotator/rotator.go:222:2: unreachable code
    # github.com/sipcapture/heplify-server/decoder
    decoder/decoder.go:299:35: possible misuse of reflect.SliceHeader

see https://github.com/golang/go/issues/40701