### PR TITLE
Do not modify Loki payload

### DIFF
--- a/remotelog/loki.go
+++ b/remotelog/loki.go
@@ -106,15 +106,6 @@ func (l *Loki) start(hCh chan *decoder.HEP) {
 
 			pktMeta.Reset()
 			pktMeta.WriteString(pkt.Payload)
-			pktMeta.WriteString(" src_ip=")
-			pktMeta.WriteString(pkt.SrcIP)
-			pktMeta.WriteString(" dst_ip=")
-			pktMeta.WriteString(pkt.DstIP)
-			if pkt.ProtoType < 110 {
-				pktMeta.WriteString(" id=")
-				pktMeta.WriteString(pkt.CID)
-			}
-
 			l.entry = entry{model.LabelSet{}, logproto.Entry{Timestamp: curPktTime}}
 
 			switch {


### PR DESCRIPTION
Note: not every message is logfmt and the forced extension breaks format parsing for JSON and pretty much any other format that's not logfmt. Alternatively a preference could be set to restore it, but I am not aware of anything using this actively or requiring it at this time.