### PR TITLE
fix (rotator): defer rows.Close after query errors checking

### DIFF
--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -336,11 +336,11 @@ func (r *Rotator) dbExecDropTables(db *sql.DB, listfile, dropfile string, d int)
 	var partName string
 
 	rows, err := db.Query(listquery)
-	defer rows.Close()
 	if err != nil {
 		logp.Err("%v", err)
 		return err
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		err := rows.Scan(&partName)
@@ -372,12 +372,14 @@ func (r *Rotator) dbExecDropTablesForFreeSpace(db *sql.DB, listfile, dropfile st
 	listquery := strings.Replace(listfile, partitionDate, partDate, -1)
 	listquery = strings.Replace(listquery, partitionTime, partTime, -1)
 	var partName string
+
 	rows, err := db.Query(listquery)
-	defer rows.Close()
 	if err != nil {
 		logp.Err("%v", err)
 		return err
 	}
+	defer rows.Close()
+
 	i := 1
 	for rows.Next() {
 		err := rows.Scan(&partName)


### PR DESCRIPTION
If db.Query returns an error, than other return values are "undefined" (they may be nil) and thus calling method rows.Close result in a panic. 
Example: [type Rows](https://pkg.go.dev/database/sql#Rows.Close)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa9f142]
goroutine 306152 [running]:
database/sql.(*Rows).close(0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/database/sql/sql.go:3083 +0x72
database/sql.(*Rows).Close(0x0, 0xc00011f180, 0xc00027dd20)
        /usr/local/go/src/database/sql/sql.go:3079 +0x33
github.com/sipcapture/heplify-server/rotator.(*Rotator).dbExecDropTablesForFreeSpace(0xc00022c000, 0xc00098c0c0, 0>
         /app/rotator/rotator.go:379 +0x3d6
github.com/sipcapture/heplify-server/rotator.(*Rotator).UsageProtection(0xc00022c000, 0xfc777f, 0xa, 0x0, 0x0)
         /app/rotator/rotator.go:271 +0x449
github.com/sipcapture/heplify-server/rotator.(*Rotator).Rotate.func3()
         /app/rotator/rotator.go:510 +0x53
github.com/robfig/cron/v3.FuncJob.Run(0xc000914730)
         /go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:136 +0x25
github.com/robfig/cron/v3.(*Cron).startJob.func1(0xc000126000, 0x1110960, 0xc000914730)
         /go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:312 +0x69
created by github.com/robfig/cron/v3.(*Cron).startJob
         /go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:310 +0x73
```