### PR TITLE
Update lib/pq dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gobwas/ws v1.0.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1
-	github.com/lib/pq v1.7.0
+	github.com/lib/pq v1.10.9
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/negbie/cert v0.0.0-20190324145947-d1018a8fb00f
 	github.com/negbie/logp v0.0.0-20190313141056-04cebff7f846

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lib/pq v1.7.0 h1:h93mCPfUSkaul3Ka/VG8uZdmW1uMHDGxzu0NWHuJmHY=
-github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=


### PR DESCRIPTION
Sometimes, when there are no calls for several hours, the service loses its connection to the database. When calls resume, the service fails to save anything to the database and logs the following errors:
```
...
2024/11/27 22:04:53.975003 postgres.go:259: ERR write tcp 192.168.4.50:36174->192.168.5.25:5432: write: broken pipe
2024/11/27 22:04:54.517898 postgres.go:259: ERR write tcp 192.168.4.50:36174->192.168.5.25:5432: write: broken pipe
2024/11/27 22:04:57.975863 postgres.go:259: ERR write tcp 192.168.4.50:36174->192.168.5.25:5432: write: broken pipe
2024/11/27 22:04:58.518497 postgres.go:259: ERR write tcp 192.168.4.50:36174->192.168.5.25:5432: write: broken pipe
2024/11/27 22:05:02.519271 postgres.go:259: ERR write tcp 192.168.4.50:36174->192.168.5.25:5432: write: broken pipe
...
```
According to `netstat`, there is no TCP connection with PostgreSQL at the moment, and according to `tcpdump`, it is not attempting to establish the new one.

I found that there was an issue (https://github.com/lib/pq/issues/870) with the same problem, which was fixed in lib/pq v1.9.0. However, heplify-server is still using v1.7.0.
Would you mind upgrading to the latest version of lib/pq?
