### PR TITLE
Adding call_id, from and to labels to loki logs

### DIFF
--- a/remotelog/loki.go
+++ b/remotelog/loki.go
@@ -136,13 +136,16 @@ func (l *Loki) start(hCh chan *decoder.HEP) {
 			switch {
 			case pkt.SIP != nil && pkt.ProtoType == 1:
 				l.entry.labels["method"] = model.LabelValue(pkt.SIP.CseqMethod)
+				l.entry.labels["call_id"] = model.LabelValue(pkt.SIP.CallID)
+				l.entry.labels["from"] = model.LabelValue(pkt.SIP.From.Val)
+				l.entry.labels["to"] = model.LabelValue(pkt.SIP.To.Val)
 				l.entry.labels["response"] = model.LabelValue(pkt.SIP.FirstMethod)
 				protocol := ""
 				if pkt.Protocol == 6 {
 					protocol = "tcp"
 				} else if pkt.Protocol == 17 {
 					protocol = "udp"
-				} 
+				}
 				l.entry.labels["protocol"] = model.LabelValue(protocol)
 			case pkt.ProtoType == 100:
 				protocol := "udp"

--- a/sipparser/parser.go
+++ b/sipparser/parser.go
@@ -189,7 +189,7 @@ func (s *SipMsg) addHdr(str string) {
 			s.parseVia(s.hdrv)
 		case s.hdr == "From" || s.hdr == "FROM" || s.hdr == "from":
 			s.parseFrom(s.hdrv)
-		case s.hdr == "Call-ID" || s.hdr == "CALL-ID" || s.hdr == "Call-Id" || s.hdr == "Call-id" || s.hdr == "call-id":
+		case s.hdr == "Call-ID" || s.hdr == "CALL-ID" || s.hdr == "Call-Id" || s.hdr == "Call-id" || s.hdr == "call-id" || s.hdr == "i":
 			s.CallID = s.hdrv
 		case s.hdr == "CSeq" || s.hdr == "CSEQ" || s.hdr == "Cseq" || s.hdr == "cseq":
 			s.CseqVal = s.hdrv


### PR DESCRIPTION
Building a backend that had a ton of logs with Homer and Loki required adding those labels for performance purposes. Better query times by those labels. Added to rtcp to so it could correlate all call packets with one search by cid. 