### PR TITLE
WIP: lineproto support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,12 @@ type HeplifyServer struct {
 	LokiHEPFilter       []int    `default:"1,5,100"`
 	LokiIPPortLabels    bool     `default:"false"`
 	LokiAllowOutOfOrder bool     `default:"false"`
+	LineprotoURL        string   `default:""`
+	LineprotoBulk       int      `default:"400"`
+	LineprotoTimer      int      `default:"4"`
+	LineprotoBuffer     int      `default:"100000"`
+	LineprotoHEPFilter  []int    `default:"1,5,100"`
+	LineprotoIPPortLabels bool   `default:"false"`
 	ForceHEPPayload     []int    `default:""`
 	PromAddr            string   `default:":9096"`
 	PromTargetIP        string   `default:""`

--- a/config/webconfig.go
+++ b/config/webconfig.go
@@ -41,6 +41,16 @@ func WebConfig(r *http.Request) (*HeplifyServer, error) {
 	if webSetting.LokiBuffer, err = strconv.Atoi(r.FormValue("LokiBuffer")); err != nil {
 		return nil, err
 	}
+	webSetting.LineprotoURL = r.FormValue("LineprotoURL")
+	if webSetting.LineprotoBulk, err = strconv.Atoi(r.FormValue("LineprotoBulk")); err != nil {
+		return nil, err
+	}
+	if webSetting.LineprotoTimer, err = strconv.Atoi(r.FormValue("LineprotoTimer")); err != nil {
+		return nil, err
+	}
+	if webSetting.LineprotoBuffer, err = strconv.Atoi(r.FormValue("LineprotoBuffer")); err != nil {
+		return nil, err
+	}
 	DBShema := r.FormValue("DBShema")
 	if DBShema == "homer5" {
 		webSetting.DBShema = DBShema
@@ -221,6 +231,22 @@ var WebForm = `
 		<div>
 			<label>LokiBuffer</label>
 			<input  type="number" name="LokiBuffer" placeholder="{{.LokiBuffer}}" value="{{.LokiBuffer}}" min="100" max="10000000">
+		</div>
+		<div>
+			<label>LineprotoURL</label>
+			<input  type="text" name="LineprotoURL" placeholder="{{.LineprotoURL}}" value="{{.LineprotoURL}}">
+		</div>
+		<div>
+			<label>LineprotoBulk</label>
+			<input  type="number" name="LineprotoBulk" placeholder="{{.LineprotoBulk}}" value="{{.LineprotoBulk}}" min="50" max="20000">
+		</div>
+		<div>
+			<label>LineprotoTimer</label>
+			<input  type="number" name="LineprotoTimer" placeholder="{{.LineprotoTimer}}" value="{{.LineprotoTimer}}" min="2" max="300">
+		</div>
+		<div>
+			<label>LineprotoBuffer</label>
+			<input  type="number" name="LineprotoBuffer" placeholder="{{.LineprotoBuffer}}" value="{{.LineprotoBuffer}}" min="100" max="10000000">
 		</div>
 		<div>
 			<label>DBShema</label>

--- a/example/lineproto_config.toml
+++ b/example/lineproto_config.toml
@@ -1,0 +1,62 @@
+# Example configuration for heplify-server with lineproto output
+# This configuration sends HEP objects to an InfluxDB compatible backend using line protocol
+
+# HEP Input Configuration
+HEPAddr = "0.0.0.0:9060"
+HEPTCPAddr = ""
+HEPTLSAddr = ""
+HEPWSAddr = ""
+
+# Database Configuration (optional - can be used alongside lineproto)
+DBDriver = "mysql"
+DBAddr = "localhost:3306"
+DBUser = "root"
+DBPass = ""
+DBDataTable = "homer_data"
+DBConfTable = "homer_configuration"
+DBBulk = 400
+DBTimer = 4
+DBBuffer = 400000
+DBWorker = 8
+
+# Prometheus Metrics (optional)
+PromAddr = ":9096"
+
+# Line Protocol Output Configuration
+# URL for InfluxDB compatible backend (e.g., InfluxDB 2.x, InfluxDB Cloud, etc.)
+LineprotoURL = "http://localhost:8086/api/v2/write?org=myorg&bucket=heplify"
+LineprotoBulk = 400
+LineprotoTimer = 4
+LineprotoBuffer = 100000
+LineprotoHEPFilter = [1, 5, 100]  # Filter HEP protocol types: 1=SIP, 5=RTCP, 100=LOG
+LineprotoIPPortLabels = false     # Set to true to include src_ip, src_port, dst_ip, dst_port as tags
+
+# Elasticsearch Output (optional - can be used alongside lineproto)
+ESAddr = ""
+ESUser = ""
+ESPass = ""
+
+# Loki Output (optional - can be used alongside lineproto)
+LokiURL = ""
+LokiBulk = 400
+LokiTimer = 4
+LokiBuffer = 100000
+LokiHEPFilter = [1, 5, 100]
+LokiIPPortLabels = false
+LokiAllowOutOfOrder = false
+
+# General Settings
+LogLvl = "info"
+LogStd = true
+LogSys = false
+Dedup = false
+
+# Script Engine (optional)
+ScriptEnable = false
+ScriptEngine = "lua"
+ScriptFolder = ""
+ScriptHEPFilter = [1, 5, 100]
+
+# TLS Configuration
+TLSCertFolder = "."
+TLSMinVersion = "1.2" 

--- a/remotelog/lineproto.go
+++ b/remotelog/lineproto.go
@@ -1,0 +1,306 @@
+package remotelog
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/negbie/logp"
+	"github.com/sipcapture/heplify-server/config"
+	"github.com/sipcapture/heplify-server/decoder"
+)
+
+const (
+	lineprotoContentType = "application/octet-stream"
+	lineprotoPostPath    = "/api/v2/write"
+	lineprotoJobName     = "heplify-server"
+	lineprotoMaxErrMsgLen = 1024
+)
+
+type LineprotoEntry struct {
+	measurement string
+	tags        map[string]string
+	fields      map[string]interface{}
+	timestamp   time.Time
+}
+
+type Lineproto struct {
+	URL             string
+	BatchWait       time.Duration
+	BatchSize       int
+	IPPortLabels    bool
+	entries         []LineprotoEntry
+}
+
+func (l *Lineproto) setup() error {
+	l.BatchSize = config.Setting.LineprotoBulk * 1024
+	l.BatchWait = time.Duration(config.Setting.LineprotoTimer) * time.Second
+	l.URL = config.Setting.LineprotoURL
+	l.IPPortLabels = config.Setting.LineprotoIPPortLabels
+
+	u, err := url.Parse(l.URL)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(u.Path, lineprotoPostPath) {
+		u.Path = lineprotoPostPath
+		q := u.Query()
+		u.RawQuery = q.Encode()
+		l.URL = u.String()
+	}
+
+	// Test connection by making a simple GET request to the base URL
+	baseURL := u.String()
+	baseURL = strings.Replace(baseURL, lineprotoPostPath, "/ping", -1)
+	_, err = http.Get(baseURL)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *Lineproto) start(hCh chan *decoder.HEP) {
+	var (
+		pktMeta     strings.Builder
+		curPktTime  time.Time
+		batch       []LineprotoEntry
+		batchSize   = 0
+		maxWait     = time.NewTimer(l.BatchWait)
+		hostname    string
+	)
+
+	defer func() {
+		if err := l.sendBatch(batch); err != nil {
+			logp.Err("lineproto flush: %v", err)
+		}
+	}()
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		logp.Warn("Unable to obtain hostname: %v", err)
+	}
+
+	for {
+		select {
+		case pkt, ok := <-hCh:
+			if !ok {
+				return
+			}
+			curPktTime = pkt.Timestamp
+
+			pktMeta.Reset()
+
+			if pkt.ProtoString == "rtcp" {
+				var document map[string]interface{}
+				err := json.Unmarshal([]byte(pkt.Payload), &document)
+				if err != nil {
+					logp.Err("Unable to decode rtcp json: %v", err)
+					pktMeta.WriteString(pkt.Payload)
+				} else {
+					document["cid"] = pkt.CID
+					documentJson, err := json.Marshal(document)
+					if err != nil {
+						logp.Err("Unable to re-generate rtcp json: %v", err)
+						pktMeta.WriteString(pkt.Payload)
+					} else {
+						pktMeta.Write(documentJson)
+					}
+				}
+			} else {
+				pktMeta.WriteString(pkt.Payload)
+			}
+
+			entry := l.createEntry(pkt, curPktTime, pktMeta.String(), hostname)
+
+			if batchSize+len(pktMeta.String()) > l.BatchSize {
+				if err := l.sendBatch(batch); err != nil {
+					logp.Err("send size batch: %v", err)
+				}
+				batchSize = 0
+				batch = []LineprotoEntry{}
+				maxWait.Reset(l.BatchWait)
+			}
+
+			batchSize += len(pktMeta.String())
+			batch = append(batch, entry)
+
+		case <-maxWait.C:
+			if len(batch) > 0 {
+				if err := l.sendBatch(batch); err != nil {
+					logp.Err("send time batch: %v", err)
+				}
+				batchSize = 0
+				batch = []LineprotoEntry{}
+			}
+			maxWait.Reset(l.BatchWait)
+		}
+	}
+}
+
+func (l *Lineproto) createEntry(pkt *decoder.HEP, timestamp time.Time, payload string, hostname string) LineprotoEntry {
+	entry := LineprotoEntry{
+		measurement: fmt.Sprintf("hep_%d", pkt.ProtoType),
+		tags:        make(map[string]string),
+		fields:      make(map[string]interface{}),
+		timestamp:   timestamp,
+	}
+
+	// Set IP/Port tags (always included as per example)
+	entry.tags["src_ip"] = pkt.SrcIP
+	entry.tags["dst_ip"] = pkt.DstIP
+	entry.tags["src_port"] = strconv.FormatUint(uint64(pkt.SrcPort), 10)
+	entry.tags["dst_port"] = strconv.FormatUint(uint64(pkt.DstPort), 10)
+
+	// Set fields
+	entry.fields["create_date"] = timestamp.UnixMilli() // milliseconds timestamp as integer
+	entry.fields["payload"] = payload
+	entry.fields["payload_size"] = len(payload)
+
+	// Add SIP-specific fields when available
+	if pkt.SIP != nil && pkt.ProtoType == 1 {
+		if pkt.SIP.CseqMethod != "" {
+			entry.fields["sip_method"] = pkt.SIP.CseqMethod
+		}
+		if pkt.CID != "" {
+			entry.fields["call_id"] = pkt.CID
+		}
+	}
+
+	return entry
+}
+
+func (l *Lineproto) sendBatch(batch []LineprotoEntry) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	buf, err := l.encodeBatch(batch)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = l.send(ctx, buf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *Lineproto) encodeBatch(batch []LineprotoEntry) ([]byte, error) {
+	var buf strings.Builder
+
+	for _, entry := range batch {
+		// Build the line protocol format: measurement,tag1=value1,tag2=value2 field1=value1,field2=value2 timestamp
+		buf.WriteString(entry.measurement)
+
+		// Add tags (sorted alphabetically)
+		if len(entry.tags) > 0 {
+			buf.WriteString(",")
+			tagKeys := make([]string, 0, len(entry.tags))
+			for k := range entry.tags {
+				tagKeys = append(tagKeys, k)
+			}
+			sort.Strings(tagKeys)
+			tagPairs := make([]string, 0, len(entry.tags))
+			for _, k := range tagKeys {
+				v := entry.tags[k]
+				escapedKey := l.escapeTag(k)
+				escapedValue := l.escapeTag(v)
+				tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", escapedKey, escapedValue))
+			}
+			buf.WriteString(strings.Join(tagPairs, ","))
+		}
+
+		// Add fields
+		buf.WriteString(" ")
+		fieldPairs := make([]string, 0, len(entry.fields))
+		for k, v := range entry.fields {
+			escapedKey := l.escapeField(k)
+			switch val := v.(type) {
+			case string:
+				escapedValue := l.escapeString(val)
+				fieldPairs = append(fieldPairs, fmt.Sprintf("%s=\"%s\"", escapedKey, escapedValue))
+			case int, int32, int64, uint, uint32, uint64:
+				fieldPairs = append(fieldPairs, fmt.Sprintf("%s=%di", escapedKey, val))
+			case float32, float64:
+				fieldPairs = append(fieldPairs, fmt.Sprintf("%s=%f", escapedKey, val))
+			case bool:
+				fieldPairs = append(fieldPairs, fmt.Sprintf("%s=%t", escapedKey, val))
+			default:
+				// Convert to string for unknown types
+				escapedValue := l.escapeString(fmt.Sprintf("%v", val))
+				fieldPairs = append(fieldPairs, fmt.Sprintf("%s=\"%s\"", escapedKey, escapedValue))
+			}
+		}
+		buf.WriteString(strings.Join(fieldPairs, ","))
+
+		// Add timestamp (nanoseconds)
+		buf.WriteString(fmt.Sprintf(" %d\n", entry.timestamp.UnixNano()))
+	}
+
+	return []byte(buf.String()), nil
+}
+
+func (l *Lineproto) escapeTag(s string) string {
+	// Escape commas, spaces, and equals signs in tag keys and values
+	s = strings.ReplaceAll(s, "\\", "\\\\") // escape backslash first
+	s = strings.ReplaceAll(s, ",", "\\,")
+	s = strings.ReplaceAll(s, " ", "\\ ")
+	s = strings.ReplaceAll(s, "=", "\\=")
+	return s
+}
+
+func (l *Lineproto) escapeField(s string) string {
+	// Escape spaces in field keys
+	s = strings.ReplaceAll(s, ",", "\\,")
+	s = strings.ReplaceAll(s, " ", "\\ ")
+	s = strings.ReplaceAll(s, "=", "\\=")
+	return s
+}
+
+func (l *Lineproto) escapeString(s string) string {
+	// Escape backslash first, then quotes
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return s
+}
+
+func (l *Lineproto) send(ctx context.Context, buf []byte) (int, error) {
+	req, err := http.NewRequest("POST", l.URL, bytes.NewReader(buf))
+	if err != nil {
+		return -1, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", lineprotoContentType)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+
+	logp.Debug("lineproto", "%s request with %d bytes to %s - %v response", req.Method, len(buf), l.URL, resp.StatusCode)
+
+	if resp.StatusCode/100 != 2 {
+		scanner := bufio.NewScanner(io.LimitReader(resp.Body, lineprotoMaxErrMsgLen))
+		line := ""
+		if scanner.Scan() {
+			line = scanner.Text()
+		}
+		err = fmt.Errorf("server returned HTTP status %s (%d): %s", resp.Status, resp.StatusCode, line)
+	}
+	return resp.StatusCode, err
+} 

--- a/remotelog/lineproto_test.go
+++ b/remotelog/lineproto_test.go
@@ -1,0 +1,180 @@
+package remotelog
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/sipcapture/heplify-server/sipparser"
+)
+
+func TestLineprotoCreateEntry(t *testing.T) {
+	// Create a test HEP packet
+	hep := &decoder.HEP{
+		Version:    3,
+		Protocol:   17, // UDP
+		SrcIP:      "192.168.1.1",
+		DstIP:      "192.168.1.2",
+		SrcPort:    5060,
+		DstPort:    5060,
+		ProtoType:  1, // SIP
+		NodeID:     1,
+		CID:        "a84b4c76e66710@example.com",
+		Timestamp:  time.Unix(1618426800, 0),
+		Payload:    "INVITE sip:user@example.com SIP/2.0\r\nVia: SIP/2.0/UDP 192.168.1.1:5060\r\n\r\n",
+		SIP: &sipparser.SipMsg{
+			CseqMethod: "INVITE",
+		},
+	}
+
+	lp := &Lineproto{}
+	entry := lp.createEntry(hep, hep.Timestamp, hep.Payload, "test-host")
+
+	// Test measurement name
+	expectedMeasurement := "hep_1"
+	if entry.measurement != expectedMeasurement {
+		t.Errorf("Expected measurement %s, got %s", expectedMeasurement, entry.measurement)
+	}
+
+	// Test tags
+	expectedTags := map[string]string{
+		"src_ip":   "192.168.1.1",
+		"dst_ip":   "192.168.1.2",
+		"src_port": "5060",
+		"dst_port": "5060",
+	}
+
+	for k, v := range expectedTags {
+		if entry.tags[k] != v {
+			t.Errorf("Expected tag %s=%s, got %s", k, v, entry.tags[k])
+		}
+	}
+
+	// Test fields
+	if entry.fields["create_date"] != int64(1618426800000) {
+		t.Errorf("Expected create_date %d, got %v", int64(1618426800000), entry.fields["create_date"])
+	}
+
+	if entry.fields["payload"] != hep.Payload {
+		t.Errorf("Expected payload %s, got %s", hep.Payload, entry.fields["payload"])
+	}
+
+	if entry.fields["payload_size"] != len(hep.Payload) {
+		t.Errorf("Expected payload_size %d, got %v", len(hep.Payload), entry.fields["payload_size"])
+	}
+
+	if entry.fields["sip_method"] != "INVITE" {
+		t.Errorf("Expected sip_method INVITE, got %s", entry.fields["sip_method"])
+	}
+
+	if entry.fields["call_id"] != "a84b4c76e66710@example.com" {
+		t.Errorf("Expected call_id %s, got %s", "a84b4c76e66710@example.com", entry.fields["call_id"])
+	}
+}
+
+func TestLineprotoEncodeBatch(t *testing.T) {
+	// Create test entries
+	entries := []LineprotoEntry{
+		{
+			measurement: "hep_1",
+			tags: map[string]string{
+				"src_ip":   "192.168.1.1",
+				"dst_ip":   "192.168.1.2",
+				"src_port": "5060",
+				"dst_port": "5060",
+			},
+			fields: map[string]interface{}{
+				"create_date":   int64(1618426800000),
+				"sip_method":    "INVITE",
+				"call_id":       "a84b4c76e66710@example.com",
+				"payload_size":  int64(245),
+				"payload":       "INVITE sip:user@example.com SIP/2.0...",
+			},
+			timestamp: time.Unix(1618426800, 0),
+		},
+	}
+
+	lp := &Lineproto{}
+	buf, err := lp.encodeBatch(entries)
+	if err != nil {
+		t.Fatalf("Failed to encode batch: %v", err)
+	}
+
+	// Convert to string for easier testing
+	output := string(buf)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line, got %d", len(lines))
+	}
+
+	line := lines[0]
+	
+	// Check that the line contains expected components
+	if !strings.Contains(line, "hep_1,dst_ip=192.168.1.2,dst_port=5060,src_ip=192.168.1.1,src_port=5060") {
+		t.Errorf("Line missing expected tags: %s", line)
+	}
+
+	if !strings.Contains(line, "create_date=1618426800000i") {
+		t.Errorf("Line missing expected create_date field: %s", line)
+	}
+
+	if !strings.Contains(line, "sip_method=\"INVITE\"") {
+		t.Errorf("Line missing expected sip_method field: %s", line)
+	}
+
+	if !strings.Contains(line, "call_id=\"a84b4c76e66710@example.com\"") {
+		t.Errorf("Line missing expected call_id field: %s", line)
+	}
+
+	if !strings.Contains(line, "payload_size=245i") {
+		t.Errorf("Line missing expected payload_size field: %s", line)
+	}
+
+	// Check timestamp format (nanoseconds)
+	if !strings.HasSuffix(line, " 1618426800000000000") {
+		t.Errorf("Line missing expected timestamp: %s", line)
+	}
+}
+
+func TestLineprotoEscapeFunctions(t *testing.T) {
+	lp := &Lineproto{}
+
+	// Test tag escaping
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"normal", "normal"},
+		{"with,comma", "with\\,comma"},
+		{"with space", "with\\ space"},
+		{"with=equals", "with\\=equals"},
+		{"with\\backslash", "with\\\\backslash"},
+	}
+
+	for _, tc := range testCases {
+		result := lp.escapeTag(tc.input)
+		if result != tc.expected {
+			t.Errorf("escapeTag(%s) = %s, expected %s", tc.input, result, tc.expected)
+		}
+	}
+
+	// Test string escaping
+	stringTestCases := []struct {
+		input    string
+		expected string
+	}{
+		{"normal", "normal"},
+		{"with\"quote", "with\\\"quote"},
+		{"with\\backslash", "with\\\\backslash"},
+		{"with\"quote\\backslash", "with\\\"quote\\\\backslash"},
+	}
+
+	for _, tc := range stringTestCases {
+		result := lp.escapeString(tc.input)
+		if result != tc.expected {
+			t.Errorf("escapeString(%s) = %s, expected %s", tc.input, result, tc.expected)
+		}
+	}
+} 

--- a/remotelog/remotelog.go
+++ b/remotelog/remotelog.go
@@ -19,6 +19,7 @@ func New(name string) *Remotelog {
 	var register = map[string]RemoteHandler{
 		"elasticsearch": new(Elasticsearch),
 		"loki":          new(Loki),
+		"lineproto":     new(Lineproto),
 	}
 
 	return &Remotelog{

--- a/server/server.go
+++ b/server/server.go
@@ -19,25 +19,27 @@ import (
 )
 
 type HEPInput struct {
-	inputCh    chan []byte
-	dbCh       chan *decoder.HEP
-	promCh     chan *decoder.HEP
-	esCh       chan *decoder.HEP
-	lokiCh     chan *decoder.HEP
-	wg         *sync.WaitGroup
-	buffer     *sync.Pool
-	exitUDP    chan bool
-	exitTCP    chan bool
-	exitTLS    chan bool
-	exitWS     chan bool
-	exitWorker chan bool
-	quit       chan bool
-	stopped    uint32
-	stats      HEPStats
-	useDB      bool
-	usePM      bool
-	useES      bool
-	useLK      bool
+	inputCh      chan []byte
+	dbCh         chan *decoder.HEP
+	promCh       chan *decoder.HEP
+	esCh         chan *decoder.HEP
+	lokiCh       chan *decoder.HEP
+	lineprotoCh  chan *decoder.HEP
+	wg           *sync.WaitGroup
+	buffer       *sync.Pool
+	exitUDP      chan bool
+	exitTCP      chan bool
+	exitTLS      chan bool
+	exitWS       chan bool
+	exitWorker   chan bool
+	quit         chan bool
+	stopped      uint32
+	stats        HEPStats
+	useDB        bool
+	usePM        bool
+	useES        bool
+	useLK        bool
+	useLP        bool
 }
 
 type HEPStats struct {
@@ -77,6 +79,10 @@ func NewHEPInput() *HEPInput {
 	if len(config.Setting.LokiURL) > 2 {
 		h.useLK = true
 		h.lokiCh = make(chan *decoder.HEP, config.Setting.LokiBuffer)
+	}
+	if len(config.Setting.LineprotoURL) > 2 {
+		h.useLP = true
+		h.lineprotoCh = make(chan *decoder.HEP, config.Setting.LineprotoBuffer)
 	}
 
 	return h
@@ -136,6 +142,16 @@ func (h *HEPInput) Run() {
 			logp.Err("%v", err)
 		}
 		defer l.End()
+	}
+
+	if h.useLP {
+		lp := remotelog.New("lineproto")
+		lp.Chan = h.lineprotoCh
+
+		if err := lp.Run(); err != nil {
+			logp.Err("%v", err)
+		}
+		defer lp.End()
 	}
 
 	if h.useDB && config.Setting.DBRotate &&
@@ -278,6 +294,22 @@ func (h *HEPInput) worker() {
 						default:
 							if time.Since(lastWarn) > 1e9 {
 								logp.Warn("overflowing loki channel")
+							}
+							lastWarn = time.Now()
+						}
+						break
+					}
+				}
+			}
+
+			if h.useLP {
+				for _, v := range config.Setting.LineprotoHEPFilter {
+					if hepPkt.ProtoType == uint32(v) {
+						select {
+						case h.lineprotoCh <- hepPkt:
+						default:
+							if time.Since(lastWarn) > 1e9 {
+								logp.Warn("overflowing lineproto channel")
 							}
 							lastWarn = time.Now()
 						}


### PR DESCRIPTION
# Line Protocol Output (lp) support for heplify-server

This PR introduces a new output option for heplify-server: **lineproto**, which enables sending HEP objects as InfluxDB-compatible line protocol batches to GigAPI or any InfluxDB or compatible backend.

## Key Features

- **New Output:** `lineproto` output module, selectable via config.
- **Format:** Each HEP object is formatted as a line-protocol series (e.g., `hep_1,src_ip=... field1=...,field2=... timestamp`).
- **Measurement:** Series name reflects HEP type (e.g., `hep_1`, `hep_100`).
- **Tags:** Includes `src_ip`, `dst_ip`, `src_port`, `dst_port` as tags.
- **Fields:** Includes `create_date`, `payload`, `payload_size`, and SIP-specific fields like `sip_method` and `call_id` when available.
- **Timestamp:** Uses the original packet timestamp for correct time-series ordering.
- **Batching:** Configurable batch size and timer for efficient bulk inserts.
- **Filtering:** Supports filtering by HEP protocol type.
- **Configurable:** All settings available via config file and web UI.
- **Documentation & Tests:** Comprehensive documentation and test coverage included.

## Example Output
```
hep_1,src_ip=192.168.1.1,dst_ip=192.168.1.2,src_port=5060,dst_port=5060 create_date=1618426800000i,sip_method="INVITE",call_id="a84b4c76e66710@example.com",payload_size=245i,payload="..." 1618426800000000000
```

## Configuration

Add to your `heplify-server.toml`:

```toml
LineprotoURL = "http://localhost:8086/api/v2/write?org=myorg&bucket=heplify"
LineprotoBulk = 400
LineprotoTimer = 4
LineprotoBuffer = 100000
LineprotoHEPFilter = [1, 5, 100]
```

This feature enables seamless integration of heplify-server with GigAPI/InfluxDB and other time-series databases supporting lineprotocol ingestion, supporting advanced analytics, dashboards, and long-term storage for SIP and HEP data.
