### PR TITLE
Support parsing SIP response with empty reason phrase

### DIFF
--- a/sipparser/parser_test.go
+++ b/sipparser/parser_test.go
@@ -16,12 +16,20 @@ import (
 
 var testInviteMsg = "INVITE sip:15554440000@X.X.X.X:5060;user=phone SIP/2.0\r\nVia: SIP/2.0/UDP X.X.X.X:5060;branch=z9hG4bK34133a599ll241207INV21d7d0684e84a2d2\r\nMax-Forwards: 35\r\nContact: <sip:X.X.X.X:5060>\r\nTo: <sip:15554440000@X.X.X.X;user=phone;noa=national>\r\nFrom: \"Unavailable\"<sip:X.X.X.X;user=phone;noa=national>;tag=21d7d068-co2149-FOOI003\r\nCall-ID: 1393184968_47390262@domain.com\r\nCSeq: 214901 INVITE\r\nAuthorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\", algorithm=MD5, uri=\"sip:foo.bar.com\", nonce=\"4f6d7a1d\", response=\"6a79a5c75572b0f6a18963ae04e971cf\", opaque=\"\"\r\nAllow: INVITE,ACK,CANCEL,BYE,REFER,OPTIONS,NOTIFY,SUBSCRIBE,PRACK,INFO\r\nContent-Type: application/sdp\r\nDate: Thu, 29 Sep 2011 16:54:42 GMT\r\nUser-Agent: FAKE-UA-DATA\r\nP-Asserted-Identity: \"Unavailable\"<sip:Restricted@X.X.X.X:5060>\r\nContent-Length: 322\r\n\r\nv=0\r\no=- 567791720 567791720 IN IP4 X.X.X.X\r\ns=FAKE-DATA\r\nc=IN IP4 X.X.X.X\r\nt=0 0\r\nm=audio 17354 RTP/AVP 0 8 86 18 96\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:86 G726-32/8000\r\na=rtpmap:18 G729/8000\r\na=rtpmap:96 telephone-event/8000\r\na=maxptime:20\r\na=fmtp:18 annexb=yes\r\na=fmtp:96 0-15\r\na=sendrecv\r\n"
 var test400ErrorResp = "SIP/2.0 400 Bad Request\r\n"
+var test500ErrorNoReasonResp = "SIP/2.0 500 \r\n"
 
-// should succeed, i.e. not produce an error. 
+// should succeed, i.e. not produce an error.
 func TestParse400Err(t *testing.T) {
 	s := ParseMsg(test400ErrorResp, nil, nil)
 	if s.Error != nil {
 		t.Errorf("[TestParse400Err] Error parsing msg. Received: %v", s.Error)
+	}
+}
+
+func TestParse500ErrNoReason(t *testing.T) {
+	s := ParseMsg(test500ErrorNoReasonResp, nil, nil)
+	if s.Error != nil {
+		t.Errorf("[TestParse500ErrNoReason] Error parsing msg. Received: %v", s.Error)
 	}
 }
 

--- a/sipparser/startline.go
+++ b/sipparser/startline.go
@@ -71,7 +71,7 @@ func parseStartLine(s *StartLine) parseStartLineStateFn {
 
 func parseStartLineResponse(s *StartLine) parseStartLineStateFn {
 	parts := strings.SplitN(s.Val, " ", 3)
-	if len(parts) != 3 {
+	if len(parts) < 2 || len(parts) > 3 {
 		s.Error = errors.New("parseStartLineRespone err: err getting parts from LWS")
 		return nil
 	}
@@ -87,7 +87,9 @@ func parseStartLineResponse(s *StartLine) parseStartLineStateFn {
 	}
 	s.Version = parts[0][charPos+1:]
 	s.Resp = parts[1]
-	s.RespText = parts[2]
+	if len(parts) > 2 {
+		s.RespText = parts[2]
+	}
 	return nil
 }
 

--- a/sipparser/startline_test.go
+++ b/sipparser/startline_test.go
@@ -23,6 +23,18 @@ func TestStartLine(t *testing.T) {
 	if s.RespText != "Request Cancelled" {
 		t.Error("[TestStartLine] Error parsing startline: SIP/2.0 487 Request Cancelled.  s.RespText should be \"Request Cancelled\".")
 	}
+	str = "SIP/2.0 500"
+	s = &StartLine{Val: str}
+	s.run()
+	if s.Type != SIP_RESPONSE {
+		t.Error("[TestStartLine] Error parsing startline: SIP/2.0 500.  s.Type should be \"RESPONSE\".")
+	}
+	if s.Resp != "500" {
+		t.Error("[TestStartLine] Error parsing startline: SIP/2.0 500.  s.Resp should be \"500\".")
+	}
+	if s.RespText != "" {
+		t.Error("[TestStartLine] Error parsing startline: SIP/2.0 500.  s.RespText should be \"\".")
+	}
 	str = "1412@34922@336312786@1.2.3.4:5061;transport=tcp;user=phone@home1.2.3.4                                            111111111"
 	s = ParseStartLine(str)
 	if s.Error == nil {


### PR DESCRIPTION
According to RFC 3261, the BNF for SIP responses allows an empty reason phrase. Relevant sections: 7.2 and 25.1

```
Status-Line  =  SIP-Version SP Status-Code SP Reason-Phrase CRLF
```

```
Reason-Phrase   =  *(reserved / unreserved / escaped
                   / UTF8-NONASCII / UTF8-CONT / SP / HTAB)
```