### PR TITLE
TLS with optional client auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ These depend on which features you want to use and on whether you use homer5 or 
 
 ![image](https://user-images.githubusercontent.com/20154956/54483281-ef3f5700-4850-11e9-8da1-9b8bed6186e3.png)
 
+#### HEP input listeners
+Configure the bind address for each listener in your config (flags/env/file/web):
+
+* `HEPAddr` - UDP HEP listener (default `0.0.0.0:9060`)
+* `HEPTCPAddr` - TCP HEP listener (disabled when empty)
+* `HEPTLSAddr` - TLS HEP listener (disabled when empty)
+* `HEPWSAddr` - WebSocket HEP listener (disabled when empty)
+
+When enabling TLS, also set `TLSCertFile` and `TLSKeyFile` (and optional `TLSClientCAFile`, `TLSRequireClientCert`, `TLSMinVersion`) in the same configuration source.
+
 To set up a systemd service, use the sample [service file](https://github.com/sipcapture/heplify-server/blob/master/example/) 
 and follow the instructions found at the top of the file.
 

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,9 @@ type HeplifyServer struct {
 	ScriptEngine        string   `default:"lua"`
 	ScriptFolder        string   `default:""`
 	ScriptHEPFilter     []int    `default:"1,5,100"`
-	TLSCertFolder       string   `default:"."`
-	TLSMinVersion       string   `default:"1.2"`
+	TLSCertFile           string   `default:""`
+	TLSKeyFile            string   `default:""`
+	TLSClientCAFile       string   `default:""`
+	TLSRequireClientCert  bool     `default:"false"`
+	TLSMinVersion         string   `default:"1.2"`
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/lib/pq v1.10.9
 	github.com/mailru/easyjson v0.7.1 // indirect
-	github.com/negbie/cert v0.0.0-20190324145947-d1018a8fb00f
 	github.com/negbie/logp v0.0.0-20190313141056-04cebff7f846
 	github.com/negbie/multiconfig v1.0.0
 	github.com/olivere/elastic v6.2.33+incompatible

--- a/go.sum
+++ b/go.sum
@@ -878,8 +878,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/negbie/cert v0.0.0-20190324145947-d1018a8fb00f h1:M55iH2PERd3rI05upU5PUVeKIRHaNkjJgFtrIE0G2gU=
-github.com/negbie/cert v0.0.0-20190324145947-d1018a8fb00f/go.mod h1:gu8czYryxJq/ecHYWjTXLbVSiAkxUwSNgzfPTrKEJ2k=
 github.com/negbie/logp v0.0.0-20190313141056-04cebff7f846 h1:PAr5hcOgvc2m71W4SlbUsAbUnea5lNjB5/DfIHW9f8Q=
 github.com/negbie/logp v0.0.0-20190313141056-04cebff7f846/go.mod h1:xTKf9aKLuVL0r9wxWouR+/4ctK2ywm0rTPFY2klrnOg=
 github.com/negbie/multiconfig v1.0.0 h1:JXrB+RYMhGS/xlXGJab/4g7AoAIo3tFrwHr8LN3i0fg=


### PR DESCRIPTION
Hi Team, we’ve created and tested the attached patch to add TLS termination directly into heplify-server.

We believe this could be a solid starting point to expand TLS-related capabilities over time and give operators more flexibility around protocol and deployment options.

Any feedback or guidance on whether this aligns with your roadmap would be greatly appreciated.
