### PR TITLE
feat: LokiSkipTCPPortLabels + TLS certs/mTLS (v1.60.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ These depend on which features you want to use and on whether you use homer5 or 
 
 ![image](https://user-images.githubusercontent.com/20154956/54483281-ef3f5700-4850-11e9-8da1-9b8bed6186e3.png)
 
+#### HEP input listeners
+* `HEPAddr` - UDP HEP listener (default `0.0.0.0:9060`)
+* `HEPTCPAddr` - TCP HEP listener (disabled when empty)
+* `HEPTLSAddr` - TLS HEP listener (disabled when empty)
+* `HEPWSAddr` - WebSocket HEP listener (disabled when empty)
+
+#### TLS for HEP TLS listener
+* Default (legacy): auto-generate/load a certificate under `TLSCertFolder` (default `.`)
+* Explicit certs: set `TLSCertFile` + `TLSKeyFile`
+* Optional mTLS: set `TLSClientCAFile`, and `TLSRequireClientCert = true` to require client certs
+* `TLSMinVersion` (default `1.2`)
+
 To set up a systemd service, use the sample [service file](https://github.com/sipcapture/heplify-server/blob/master/example/) 
 and follow the instructions found at the top of the file.
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const Version = "heplify-server 1.60.5"
+const Version = "heplify-server 1.60.6"
 
 var Setting HeplifyServer
 
@@ -25,6 +25,7 @@ type HeplifyServer struct {
 	LokiBuffer            int      `default:"100000"`
 	LokiHEPFilter         []int    `default:"1,5,100"`
 	LokiIPPortLabels      bool     `default:"false"`
+	LokiSkipTCPPortLabels bool     `default:"true"`
 	LokiFromToLabels      bool     `default:"false"`
 	LokiCallIDLabels      bool     `default:"false"`
 	LokiAllowOutOfOrder   bool     `default:"false"`
@@ -86,6 +87,10 @@ type HeplifyServer struct {
 	ScriptEngine          string   `default:"lua"`
 	ScriptFolder          string   `default:""`
 	ScriptHEPFilter       []int    `default:"1,5,100"`
-	TLSCertFolder         string   `default:"."`
-	TLSMinVersion         string   `default:"1.2"`
+	TLSCertFolder        string `default:"."`
+	TLSCertFile          string `default:""`
+	TLSKeyFile           string `default:""`
+	TLSClientCAFile      string `default:""`
+	TLSRequireClientCert bool   `default:"false"`
+	TLSMinVersion        string `default:"1.2"`
 }

--- a/example/homer5_config/heplify-server.toml
+++ b/example/homer5_config/heplify-server.toml
@@ -12,6 +12,7 @@ LokiBulk              = 200
 LokiTimer             = 4
 LokiBuffer            = 100000
 LokiHEPFilter         = [1,5,100]
+LokiSkipTCPPortLabels = true
 LokiAllowOutOfOrder   = false
 LokiCustomLabels      = []
 PromAddr              = ""

--- a/example/homer7_config/heplify-server.toml
+++ b/example/homer7_config/heplify-server.toml
@@ -13,6 +13,7 @@ LokiBulk              = 200
 LokiTimer             = 4
 LokiBuffer            = 100000
 LokiHEPFilter         = [1,5,100]
+LokiSkipTCPPortLabels = true
 LokiAllowOutOfOrder   = false
 LokiCustomLabels      = []
 ForceHEPPayload	      = []

--- a/example/lineproto_config.toml
+++ b/example/lineproto_config.toml
@@ -46,7 +46,8 @@ LokiBulk = 400
 LokiTimer = 4
 LokiBuffer = 100000
 LokiHEPFilter = [1, 5, 100]
-LokiIPPortLabels = false
+LokiIPPortLabels = false          # Set to true to include src_ip, src_port, dst_ip, dst_port as labels
+LokiSkipTCPPortLabels = true      # Skip port labels for TCP to reduce cardinality (when LokiIPPortLabels is true)
 LokiAllowOutOfOrder = false
 LokiCustomLabels = []
 
@@ -63,5 +64,12 @@ ScriptFolder = ""
 ScriptHEPFilter = [1, 5, 100]
 
 # TLS Configuration
+# Legacy auto-generated cert under TLSCertFolder (used when TLSCertFile/TLSKeyFile are empty)
 TLSCertFolder = "."
+# Explicit server certificate (preferred for production)
+TLSCertFile = ""
+TLSKeyFile = ""
+# Optional client certificate authentication
+TLSClientCAFile = ""
+TLSRequireClientCert = false
 TLSMinVersion = "1.2" 

--- a/remotelog/loki.go
+++ b/remotelog/loki.go
@@ -192,10 +192,7 @@ func (l *Loki) start(hCh chan *decoder.HEP) {
 			l.entry.Entry.Line = pktMeta.String()
 
 			if config.Setting.LokiIPPortLabels {
-				l.entry.labels["src_ip"] = model.LabelValue(pkt.SrcIP)
-				l.entry.labels["src_port"] = model.LabelValue(strconv.FormatUint(uint64(pkt.SrcPort), 10))
-				l.entry.labels["dst_ip"] = model.LabelValue(pkt.DstIP)
-				l.entry.labels["dst_port"] = model.LabelValue(strconv.FormatUint(uint64(pkt.DstPort), 10))
+				applyLokiIPPortLabels(&l.entry.labels, pkt)
 			}
 
 			for k, v := range pkt.CustomLokiLabels {
@@ -291,4 +288,17 @@ func (l *Loki) send(ctx context.Context, buf []byte) (int, error) {
 		err = fmt.Errorf("server returned HTTP status %s (%d): %s", resp.Status, resp.StatusCode, line)
 	}
 	return resp.StatusCode, err
+}
+
+// applyLokiIPPortLabels adds src/dst IP labels and, unless TCP port skipping is
+// enabled for TCP packets, also adds src/dst port labels.
+func applyLokiIPPortLabels(labels *model.LabelSet, pkt *decoder.HEP) {
+	(*labels)["src_ip"] = model.LabelValue(pkt.SrcIP)
+	(*labels)["dst_ip"] = model.LabelValue(pkt.DstIP)
+	// TCP source ports are typically ephemeral and explode Loki cardinality.
+	if config.Setting.LokiSkipTCPPortLabels && pkt.Protocol == 6 {
+		return
+	}
+	(*labels)["src_port"] = model.LabelValue(strconv.FormatUint(uint64(pkt.SrcPort), 10))
+	(*labels)["dst_port"] = model.LabelValue(strconv.FormatUint(uint64(pkt.DstPort), 10))
 }

--- a/remotelog/loki_test.go
+++ b/remotelog/loki_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/sipcapture/heplify-server/config"
+	"github.com/sipcapture/heplify-server/decoder"
 )
 
 func withConfig(t *testing.T, fn func()) {
@@ -95,3 +97,61 @@ func TestLokiSendSendsOrgIDHeaderAndFailsOnNon2xx(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyLokiIPPortLabels_SkipsTCPPortsByDefault(t *testing.T) {
+	withConfig(t, func() {
+		config.Setting.LokiSkipTCPPortLabels = true
+		labels := model.LabelSet{}
+		applyLokiIPPortLabels(&labels, &decoder.HEP{
+			Protocol: 6,
+			SrcIP:    "192.168.1.1",
+			DstIP:    "192.168.1.2",
+			SrcPort:  12345,
+			DstPort:  5060,
+		})
+		if _, ok := labels["src_port"]; ok {
+			t.Fatal("expected src_port to be skipped for TCP")
+		}
+		if _, ok := labels["dst_port"]; ok {
+			t.Fatal("expected dst_port to be skipped for TCP")
+		}
+		if labels["src_ip"] != "192.168.1.1" || labels["dst_ip"] != "192.168.1.2" {
+			t.Fatalf("unexpected IP labels: %v", labels)
+		}
+	})
+}
+
+func TestApplyLokiIPPortLabels_IncludesUDPPorts(t *testing.T) {
+	withConfig(t, func() {
+		config.Setting.LokiSkipTCPPortLabels = true
+		labels := model.LabelSet{}
+		applyLokiIPPortLabels(&labels, &decoder.HEP{
+			Protocol: 17,
+			SrcIP:    "192.168.1.1",
+			DstIP:    "192.168.1.2",
+			SrcPort:  5060,
+			DstPort:  5060,
+		})
+		if labels["src_port"] != "5060" || labels["dst_port"] != "5060" {
+			t.Fatalf("expected UDP ports in labels, got %v", labels)
+		}
+	})
+}
+
+func TestApplyLokiIPPortLabels_IncludesTCPPortsWhenSkipDisabled(t *testing.T) {
+	withConfig(t, func() {
+		config.Setting.LokiSkipTCPPortLabels = false
+		labels := model.LabelSet{}
+		applyLokiIPPortLabels(&labels, &decoder.HEP{
+			Protocol: 6,
+			SrcIP:    "192.168.1.1",
+			DstIP:    "192.168.1.2",
+			SrcPort:  12345,
+			DstPort:  5060,
+		})
+		if labels["src_port"] != "12345" || labels["dst_port"] != "5060" {
+			t.Fatalf("expected TCP ports when skip disabled, got %v", labels)
+		}
+	})
+}
+

--- a/server/tls.go
+++ b/server/tls.go
@@ -2,7 +2,10 @@ package input
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -45,14 +48,12 @@ func (h *HEPInput) serveTLS(addr string) {
 		logp.Err("%v", err)
 		return
 	}
+	defer ln.Close()
 
-	// get path for certificate/key storage
-	cPath := config.Setting.TLSCertFolder
 	minTLSVersion := parseTLSVersion(config.Setting.TLSMinVersion)
-	// load any existing certs, otherwise generate a new one
-	ca, err := cert.NewCertificateAuthority(filepath.Join(cPath, "heplify-server"))
+	tlsConfig, err := loadTLSConfig(minTLSVersion)
 	if err != nil {
-		logp.Err("%v", err)
+		logp.Err("TLS configuration error: %v", err)
 		return
 	}
 
@@ -61,7 +62,6 @@ func (h *HEPInput) serveTLS(addr string) {
 	for {
 		if atomic.LoadUint32(&h.stopped) == 1 {
 			logp.Info("stopping TLS listener on %s", ln.Addr())
-			ln.Close()
 			wg.Wait()
 			return
 		}
@@ -79,12 +79,74 @@ func (h *HEPInput) serveTLS(addr string) {
 			continue
 		}
 		logp.Info("new TLS connection %s -> %s", conn.RemoteAddr(), conn.LocalAddr())
+		c := conn
 		wg.Go(func() {
-			h.handleTLS(tls.Server(conn, &tls.Config{GetCertificate: ca.GetCertificate, MinVersion: minTLSVersion}))
+			h.handleTLS(tls.Server(c, tlsConfig))
 		})
 	}
+	wg.Wait()
 }
 
 func (h *HEPInput) handleTLS(c net.Conn) {
 	h.handleStream(c, "TLS")
+}
+
+// loadTLSConfig builds the TLS config for HEP TLS listeners.
+// Prefer explicit TLSCertFile/TLSKeyFile when set; otherwise fall back to the
+// legacy auto-generated certificate stored under TLSCertFolder.
+func loadTLSConfig(minTLSVersion uint16) (*tls.Config, error) {
+	certFile := config.Setting.TLSCertFile
+	keyFile := config.Setting.TLSKeyFile
+
+	if certFile != "" || keyFile != "" {
+		if certFile == "" || keyFile == "" {
+			return nil, fmt.Errorf("both TLSCertFile and TLSKeyFile must be set")
+		}
+
+		pair, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load TLS certificate/key: %w", err)
+		}
+
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{pair},
+			MinVersion:   minTLSVersion,
+		}
+
+		if config.Setting.TLSClientCAFile != "" {
+			caPEM, err := os.ReadFile(config.Setting.TLSClientCAFile)
+			if err != nil {
+				return nil, fmt.Errorf("read TLSClientCAFile: %w", err)
+			}
+			caPool := x509.NewCertPool()
+			if ok := caPool.AppendCertsFromPEM(caPEM); !ok {
+				return nil, fmt.Errorf("TLSClientCAFile did not contain any valid certificates")
+			}
+			tlsConfig.ClientCAs = caPool
+			if config.Setting.TLSRequireClientCert {
+				tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			} else {
+				tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
+			}
+		} else if config.Setting.TLSRequireClientCert {
+			return nil, fmt.Errorf("TLSClientCAFile must be set when TLSRequireClientCert is enabled")
+		}
+
+		return tlsConfig, nil
+	}
+
+	if config.Setting.TLSRequireClientCert || config.Setting.TLSClientCAFile != "" {
+		return nil, fmt.Errorf("TLSCertFile/TLSKeyFile are required when using TLS client authentication")
+	}
+
+	cPath := config.Setting.TLSCertFolder
+	ca, err := cert.NewCertificateAuthority(filepath.Join(cPath, "heplify-server"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		GetCertificate: ca.GetCertificate,
+		MinVersion:     minTLSVersion,
+	}, nil
 }

--- a/server/tls_test.go
+++ b/server/tls_test.go
@@ -1,9 +1,22 @@
 package input
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
-	"github.com/stretchr/testify/assert"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/sipcapture/heplify-server/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMinVersionConfig_Valid(t *testing.T) {
@@ -47,4 +60,114 @@ func TestMinVersionConfig_Invalid(t *testing.T) {
 			assert.Equal(t, minVersion, output)
 		}(t, test.input, test.output)
 	}
+}
+
+func withTLSConfig(t *testing.T, fn func()) {
+	t.Helper()
+	original := config.Setting
+	t.Cleanup(func() { config.Setting = original })
+	fn()
+}
+
+func writeTempCertKey(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-server"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, caTmpl, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certFile = filepath.Join(dir, "server.crt")
+	keyFile = filepath.Join(dir, "server.key")
+	caFile = filepath.Join(dir, "ca.crt")
+
+	require.NoError(t, os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER}), 0o600))
+	serverKeyBytes, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyBytes}), 0o600))
+	require.NoError(t, os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0o600))
+	return certFile, keyFile, caFile
+}
+
+func TestLoadTLSConfig_RequiresBothCertAndKey(t *testing.T) {
+	withTLSConfig(t, func() {
+		config.Setting.TLSCertFile = "only-cert.pem"
+		config.Setting.TLSKeyFile = ""
+		_, err := loadTLSConfig(tls.VersionTLS12)
+		require.Error(t, err)
+	})
+}
+
+func TestLoadTLSConfig_FromFiles(t *testing.T) {
+	withTLSConfig(t, func() {
+		certFile, keyFile, _ := writeTempCertKey(t)
+		config.Setting.TLSCertFile = certFile
+		config.Setting.TLSKeyFile = keyFile
+		cfg, err := loadTLSConfig(tls.VersionTLS12)
+		require.NoError(t, err)
+		require.Len(t, cfg.Certificates, 1)
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+		assert.Equal(t, tls.NoClientCert, cfg.ClientAuth)
+	})
+}
+
+func TestLoadTLSConfig_RequireClientCertNeedsCA(t *testing.T) {
+	withTLSConfig(t, func() {
+		certFile, keyFile, _ := writeTempCertKey(t)
+		config.Setting.TLSCertFile = certFile
+		config.Setting.TLSKeyFile = keyFile
+		config.Setting.TLSRequireClientCert = true
+		_, err := loadTLSConfig(tls.VersionTLS12)
+		require.Error(t, err)
+	})
+}
+
+func TestLoadTLSConfig_ClientAuthOptional(t *testing.T) {
+	withTLSConfig(t, func() {
+		certFile, keyFile, caFile := writeTempCertKey(t)
+		config.Setting.TLSCertFile = certFile
+		config.Setting.TLSKeyFile = keyFile
+		config.Setting.TLSClientCAFile = caFile
+		config.Setting.TLSRequireClientCert = false
+		cfg, err := loadTLSConfig(tls.VersionTLS12)
+		require.NoError(t, err)
+		assert.Equal(t, tls.VerifyClientCertIfGiven, cfg.ClientAuth)
+		require.NotNil(t, cfg.ClientCAs)
+	})
+}
+
+func TestLoadTLSConfig_ClientAuthRequired(t *testing.T) {
+	withTLSConfig(t, func() {
+		certFile, keyFile, caFile := writeTempCertKey(t)
+		config.Setting.TLSCertFile = certFile
+		config.Setting.TLSKeyFile = keyFile
+		config.Setting.TLSClientCAFile = caFile
+		config.Setting.TLSRequireClientCert = true
+		cfg, err := loadTLSConfig(tls.VersionTLS12)
+		require.NoError(t, err)
+		assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+	})
 }


### PR DESCRIPTION
## Summary
Finishes the remaining actionable open PRs:

### From #589 / #588 — Loki TCP port cardinality
- Add `LokiSkipTCPPortLabels` (default `true`)
- Skip `src_port`/`dst_port` labels for TCP when IP/port labels are enabled
- Extract `applyLokiIPPortLabels` with real unit tests

### From #584 — TLS with optional client auth
- Add `TLSCertFile` / `TLSKeyFile` for explicit server certs
- Add `TLSClientCAFile` / `TLSRequireClientCert` for optional mTLS
- **Keep** legacy `TLSCertFolder` auto-generated cert fallback (non-breaking)
- Fix listener leak on TLS config errors; avoid conn loop capture
- Unit tests for `loadTLSConfig`
- README + example config updates

Supersedes #589 and #584.
Version: **1.60.6**

## Test plan
- [x] `go test ./remotelog/ ./server/`
- [x] `go build ./...`
- [ ] Enable `LokiIPPortLabels=true` and confirm TCP traffic omits port labels by default
- [ ] Start TLS listener with `TLSCertFile`/`TLSKeyFile` and optional mTLS
- [ ] Confirm legacy `TLSCertFolder` auto-cert still works when files are unset