### PR TITLE
fix: Lua crash harden + LogDir/LogName (v1.60.7)

### DIFF
--- a/cmd/heplify-server/heplify-server.go
+++ b/cmd/heplify-server/heplify-server.go
@@ -54,8 +54,14 @@ func init() {
 		logging.ToSyslog = &config.Setting.LogSys
 	} else {
 		var fileRotator logp.FileRotator
-		fileRotator.Path = "./"
-		fileRotator.Name = "heplify-server.log"
+		fileRotator.Path = config.Setting.LogDir
+		if fileRotator.Path == "" {
+			fileRotator.Path = "./"
+		}
+		fileRotator.Name = config.Setting.LogName
+		if fileRotator.Name == "" {
+			fileRotator.Name = "heplify-server.log"
+		}
 		logging.Files = &fileRotator
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const Version = "heplify-server 1.60.6"
+const Version = "heplify-server 1.60.7"
 
 var Setting HeplifyServer
 
@@ -79,6 +79,8 @@ type HeplifyServer struct {
 	LogLvl                string   `default:"info"`
 	LogStd                bool     `default:"false"`
 	LogSys                bool     `default:"false"`
+	LogDir                string   `default:"./"`
+	LogName               string   `default:"heplify-server.log"`
 	Config                string   `default:"./heplify-server.toml"`
 	ConfigHTTPAddr        string   `default:""`
 	ConfigHTTPPW          string   `default:""`

--- a/config/webconfig.go
+++ b/config/webconfig.go
@@ -126,6 +126,12 @@ func WebConfig(r *http.Request) (*HeplifyServer, error) {
 		webSetting.Dedup = false
 	}
 	webSetting.LogLvl = r.FormValue("LogLvl")
+	if v := r.FormValue("LogDir"); v != "" {
+		webSetting.LogDir = v
+	}
+	if v := r.FormValue("LogName"); v != "" {
+		webSetting.LogName = v
+	}
 	LogSys := r.FormValue("LogSys")
 	if LogSys == "true" {
 		webSetting.LogSys = true
@@ -356,6 +362,14 @@ var WebForm = `
 		<div>
 			<label>LogLvl</label>
 			<input  type="text" name="LogLvl" placeholder="{{.LogLvl}}" value="{{.LogLvl}}">
+		</div>
+		<div>
+			<label>LogDir</label>
+			<input  type="text" name="LogDir" placeholder="{{.LogDir}}" value="{{.LogDir}}">
+		</div>
+		<div>
+			<label>LogName</label>
+			<input  type="text" name="LogName" placeholder="{{.LogName}}" value="{{.LogName}}">
 		</div>
 		<div>
 			<label>LogSys</label>

--- a/decoder/luaengine.go
+++ b/decoder/luaengine.go
@@ -39,14 +39,14 @@ type LuaEngine struct {
 }
 
 func (d *LuaEngine) GetHEPStruct() any {
-	if (*d.hepPkt) == nil {
+	if d.hepPkt == nil || (*d.hepPkt) == nil {
 		return ""
 	}
 	return (*d.hepPkt)
 }
 
 func (d *LuaEngine) GetSIPStruct() any {
-	if (*d.hepPkt).SIP == nil {
+	if d.hepPkt == nil || (*d.hepPkt) == nil || (*d.hepPkt).SIP == nil {
 		return ""
 	}
 	return (*d.hepPkt).SIP
@@ -285,7 +285,11 @@ func (d *LuaEngine) Logp(level string, message string, data any) {
 }
 
 func (d *LuaEngine) Close() {
+	if d == nil || d.LuaEngine == nil {
+		return
+	}
 	d.LuaEngine.Close()
+	d.LuaEngine = nil
 }
 
 // NewLuaEngine returns the script engine struct
@@ -339,13 +343,18 @@ func NewLuaEngine() (*LuaEngine, error) {
 }
 
 // Run will execute the script
-func (d *LuaEngine) Run(hep *HEP) error {
+func (d *LuaEngine) Run(hep *HEP) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("lua script panic: %v", r)
+		}
+	}()
+
 	/* preload */
 	d.hepPkt = &hep
 
 	for _, v := range d.functions {
-		err := d.LuaEngine.DoString(v)
-		if err != nil {
+		if err = d.LuaEngine.DoString(v); err != nil {
 			return err
 		}
 	}

--- a/decoder/luar/proxy.go
+++ b/decoder/luar/proxy.go
@@ -248,7 +248,12 @@ func unsizedKind(v reflect.Value) reflect.Kind {
 }
 
 func valueOfProxy(L *lua.State, idx int) (reflect.Value, reflect.Type) {
-	proxyId := *(*uintptr)(L.ToUserdata(idx))
+	ud := L.ToUserdata(idx)
+	if ud == nil {
+		L.RaiseError(fmt.Sprintf("No userdata proxy in arg #%d", idx))
+		return reflect.Value{}, nil
+	}
+	proxyId := *(*uintptr)(ud)
 
 	proxymu.RLock()
 	val, ok := proxyMap[proxyId]
@@ -256,6 +261,7 @@ func valueOfProxy(L *lua.State, idx int) (reflect.Value, reflect.Type) {
 
 	if !ok {
 		L.RaiseError(fmt.Sprintf("No value proxy in arg #%d", idx))
+		return reflect.Value{}, nil
 	}
 
 	return val.v, val.t

--- a/decoder/luar/proxymm.go
+++ b/decoder/luar/proxymm.go
@@ -331,7 +331,11 @@ func proxy__eq(L *lua.State) int {
 }
 
 func proxy__gc(L *lua.State) int {
-	proxyId := *(*uintptr)(L.ToUserdata(1))
+	ud := L.ToUserdata(1)
+	if ud == nil {
+		return 0
+	}
+	proxyId := *(*uintptr)(ud)
 	proxymu.Lock()
 	delete(proxyMap, proxyId)
 	proxymu.Unlock()

--- a/example/lineproto_config.toml
+++ b/example/lineproto_config.toml
@@ -72,4 +72,8 @@ TLSKeyFile = ""
 # Optional client certificate authentication
 TLSClientCAFile = ""
 TLSRequireClientCert = false
-TLSMinVersion = "1.2" 
+TLSMinVersion = "1.2"
+
+# Logging (when LogSys=false and LogStd=false, logs go to LogDir/LogName)
+LogDir = "./"
+LogName = "heplify-server.log" 

--- a/server/server.go
+++ b/server/server.go
@@ -211,6 +211,11 @@ func (h *HEPInput) End() {
 
 func (h *HEPInput) worker() {
 	defer h.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			logp.Err("HEP worker panic recovered: %v", r)
+		}
+	}()
 
 	var ok bool
 	var err error


### PR DESCRIPTION
## Summary
- **#582**: nil-safe `proxy__gc` / `valueOfProxy`, recover in `LuaEngine.Run` + HEP worker, defensive `Close` — stops crash loops on Lua GC/userdata races after 1.60.0 upgrades
- **#591 / #360**: `LogDir` (default `./`) + `LogName` (default `heplify-server.log`) for file logging path
- Version **1.60.7**

## Test plan
- [x] `go test ./decoder/ ./server/ ./remotelog/`
- [x] `go build ./...`
- [ ] With `ScriptEnable=true`, confirm worker survives bad Lua GC cases without process exit
- [ ] Set `LogDir = "/var/log/heplify"` and confirm log file appears there

Closes #582
Closes #591
Closes #360