### PR TITLE
fix: IPv6 hosts, PromTarget CIDR, DBWorker (#425/#539/#463) v1.60.8

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const Version = "heplify-server 1.60.7"
+const Version = "heplify-server 1.60.8"
 
 var Setting HeplifyServer
 

--- a/database/database.go
+++ b/database/database.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/negbie/logp"
@@ -58,8 +57,14 @@ func (d *Database) Run() error {
 		return err
 	}
 
-	if worker > runtime.NumCPU() {
-		worker = runtime.NumCPU()
+	// Cap only at a hard safety limit; DB pools are latency-bound, not CPU-bound (#463).
+	const maxDBWorker = 256
+	if worker < 1 {
+		worker = 1
+	}
+	if worker > maxDBWorker {
+		logp.Warn("DBWorker=%d exceeds max %d, clamping", worker, maxDBWorker)
+		worker = maxDBWorker
 	}
 
 	for i := 0; i < worker; i++ {

--- a/metric/prometheus.go
+++ b/metric/prometheus.go
@@ -3,6 +3,7 @@ package metric
 import (
 	"encoding/binary"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 
@@ -18,11 +19,17 @@ const (
 	cacheSize = 60 * 1024 * 1024
 )
 
+type cidrTarget struct {
+	net  *net.IPNet
+	name string
+}
+
 type Prometheus struct {
 	TargetEmpty bool
 	TargetIP    []string
 	TargetName  []string
 	TargetMap   map[string]string
+	TargetCIDRs []cidrTarget
 	TargetConf  *sync.RWMutex
 	cache       *fastcache.Cache
 }
@@ -43,9 +50,8 @@ func (p *Prometheus) setup() (err error) {
 			for i := range p.TargetName {
 				logp.Info("prometheus tag assignment %d: %s -> %s", i+1, p.TargetIP[i], p.TargetName[i])
 			}
-			p.TargetMap = make(map[string]string)
-			for i := 0; i < len(p.TargetName); i++ {
-				p.TargetMap[p.TargetIP[i]] = p.TargetName[i]
+			if err = p.setTargets(p.TargetIP, p.TargetName); err != nil {
+				return err
 			}
 		}
 	} else {
@@ -54,6 +60,46 @@ func (p *Prometheus) setup() (err error) {
 	}
 
 	return err
+}
+
+func (p *Prometheus) setTargets(ips, names []string) error {
+	exact := make(map[string]string)
+	var cidrs []cidrTarget
+	for i := 0; i < len(names); i++ {
+		ip := ips[i]
+		name := names[i]
+		if strings.Contains(ip, "/") {
+			_, network, err := net.ParseCIDR(ip)
+			if err != nil {
+				return fmt.Errorf("invalid PromTargetIP CIDR %q: %w", ip, err)
+			}
+			cidrs = append(cidrs, cidrTarget{net: network, name: name})
+			continue
+		}
+		exact[ip] = name
+	}
+	p.TargetMap = exact
+	p.TargetCIDRs = cidrs
+	return nil
+}
+
+func (p *Prometheus) matchTarget(ipStr string) (string, bool) {
+	if name, ok := p.TargetMap[ipStr]; ok {
+		return name, true
+	}
+	if len(p.TargetCIDRs) == 0 {
+		return "", false
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return "", false
+	}
+	for _, c := range p.TargetCIDRs {
+		if c.net.Contains(ip) {
+			return c.name, true
+		}
+	}
+	return "", false
 }
 
 func (p *Prometheus) expose(hCh chan *decoder.HEP) {
@@ -65,8 +111,10 @@ func (p *Prometheus) expose(hCh chan *decoder.HEP) {
 		var srcHit, dstHit bool
 
 		if !p.TargetEmpty {
-			srcTarget, srcHit = p.TargetMap[pkt.SrcIP]
-			dstTarget, dstHit = p.TargetMap[pkt.DstIP]
+			p.TargetConf.RLock()
+			srcTarget, srcHit = p.matchTarget(pkt.SrcIP)
+			dstTarget, dstHit = p.matchTarget(pkt.DstIP)
+			p.TargetConf.RUnlock()
 		}
 
 		if pkt.SIP != nil && pkt.ProtoType == 1 {

--- a/metric/prometheus_test.go
+++ b/metric/prometheus_test.go
@@ -110,3 +110,22 @@ func BenchmarkDissectJanusStats(b *testing.B) {
 		pmCh <- hep
 	}
 }
+
+func TestMatchTargetCIDR(t *testing.T) {
+	p := &Prometheus{}
+	if err := p.setTargets(
+		[]string{"10.1.2.111", "172.16.0.0/16"},
+		[]string{"sbc_access", "customer_a"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if name, ok := p.matchTarget("10.1.2.111"); !ok || name != "sbc_access" {
+		t.Fatalf("exact match failed: ok=%v name=%q", ok, name)
+	}
+	if name, ok := p.matchTarget("172.16.5.9"); !ok || name != "customer_a" {
+		t.Fatalf("cidr match failed: ok=%v name=%q", ok, name)
+	}
+	if _, ok := p.matchTarget("192.168.1.1"); ok {
+		t.Fatal("expected no match for unrelated IP")
+	}
+}

--- a/metric/reload.go
+++ b/metric/reload.go
@@ -50,9 +50,10 @@ func (p *Prometheus) reload() {
 		p.TargetIP = fsTargetIP
 		p.TargetName = fsTargetName
 		p.TargetEmpty = false
-		p.TargetMap = make(map[string]string)
-		for i := 0; i < len(p.TargetName); i++ {
-			p.TargetMap[p.TargetIP[i]] = p.TargetName[i]
+		if err := p.setTargets(fsTargetIP, fsTargetName); err != nil {
+			p.TargetConf.Unlock()
+			logp.Err("failed to reload PromTargetIP: %v", err)
+			return
 		}
 		p.TargetConf.Unlock()
 		logp.Info("successfully reloaded PromTargetIP: %#v", fsTargetIP)

--- a/sipparser/uri.go
+++ b/sipparser/uri.go
@@ -7,8 +7,6 @@ package sipparser
 
 // Imports from the go standard library
 import (
-	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -147,92 +145,4 @@ func parseUriUser(u *URI) uriStateFn {
 		}
 	}
 	return parseUriHost
-}
-
-func parseUriHost(u *URI) uriStateFn {
-	if len(u.Raw) <= u.atPos {
-		u.Error = fmt.Errorf("malformed host part inside URI: %s", u.Raw)
-		return nil
-	}
-
-	firstSemi := strings.IndexRune(u.Raw[u.atPos:], ';')
-	/*
-		if firstSemi != -1 {
-			if u.UriParams == nil {
-				u.UriParams = make([]*Param, 0)
-			}
-			if len(u.Raw[u.atPos:])-1 > firstSemi+1 {
-				uriparams := strings.Split(u.Raw[u.atPos:][firstSemi+1:], ";")
-				for i := range uriparams {
-					u.UriParams = append(u.UriParams, getParam(uriparams[i]))
-				}
-			}
-		}
-	*/
-	colon := 0
-	if firstSemi != -1 {
-		for i := range u.Raw[u.atPos : u.atPos+firstSemi] {
-			if i != len(u.Raw[u.atPos+1:u.atPos+firstSemi]) {
-				if u.Raw[u.atPos+1 : u.atPos+firstSemi][i] == ':' {
-					//u.Port = cleanWs(u.Raw[u.atPos+1 : u.atPos+firstSemi][i+1:])
-					u.Port = u.Raw[u.atPos+1 : u.atPos+firstSemi][i+1:]
-					if len(u.Port) >= 2 {
-						u.PortInt, _ = strconv.Atoi(u.Port)
-					}
-					colon = i
-				}
-				if colon != 0 {
-					break
-				}
-			}
-		}
-		switch {
-		case colon == 0:
-			if u.atPos != 0 {
-				u.Host = u.Raw[u.atPos+1 : u.atPos+firstSemi]
-			} else {
-				u.Host = u.Raw[u.atPos : u.atPos+firstSemi]
-			}
-
-		default:
-			if u.atPos != 0 {
-				u.Host = u.Raw[u.atPos+1 : u.atPos+colon+1]
-			} else {
-				u.Host = u.Raw[u.atPos : u.atPos+colon+1]
-			}
-		}
-	}
-	if firstSemi == -1 {
-		for i := range u.Raw[u.atPos+1:] {
-			if i != len(u.Raw[u.atPos+1:]) {
-				if u.Raw[u.atPos+1:][i] == ':' {
-					//u.Port = cleanWs(u.Raw[u.atPos+1:][i+1:])
-					u.Port = u.Raw[u.atPos+1:][i+1:]
-					if len(u.Port) >= 2 {
-						u.PortInt, _ = strconv.Atoi(u.Port)
-					}
-					colon = i
-				}
-				if colon != 0 {
-					break
-				}
-			}
-		}
-		switch {
-		case colon == 0:
-			if u.atPos != 0 {
-				u.Host = u.Raw[u.atPos+1:]
-			} else {
-				u.Host = u.Raw[u.atPos:]
-			}
-
-		default:
-			if u.atPos != 0 {
-				u.Host = u.Raw[u.atPos+1 : u.atPos+colon+1]
-			} else {
-				u.Host = u.Raw[u.atPos : u.atPos+colon+1]
-			}
-		}
-	}
-	return nil
 }

--- a/sipparser/uri_host.go
+++ b/sipparser/uri_host.go
@@ -1,0 +1,70 @@
+package sipparser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func parseUriHost(u *URI) uriStateFn {
+	if len(u.Raw) <= u.atPos {
+		u.Error = fmt.Errorf("malformed host part inside URI: %s", u.Raw)
+		return nil
+	}
+
+	hostPart := u.Raw
+	if u.atPos != 0 {
+		hostPart = u.Raw[u.atPos+1:]
+	}
+	if i := strings.IndexByte(hostPart, ';'); i >= 0 {
+		hostPart = hostPart[:i]
+	}
+	if i := strings.IndexByte(hostPart, '?'); i >= 0 {
+		hostPart = hostPart[:i]
+	}
+
+	// RFC 3261: IPv6 literals must be in brackets, e.g. sip:user@[2001:db8::1]:5060
+	if strings.HasPrefix(hostPart, "[") {
+		end := strings.IndexByte(hostPart, ']')
+		if end <= 1 {
+			u.Error = fmt.Errorf("malformed IPv6 host in URI: %s", u.Raw)
+			return nil
+		}
+		u.Host = hostPart[1:end]
+		rest := hostPart[end+1:]
+		if strings.HasPrefix(rest, ":") && len(rest) > 1 {
+			u.Port = rest[1:]
+			u.PortInt, _ = strconv.Atoi(u.Port)
+		}
+		return nil
+	}
+
+	// Unbracketed IPv6 (multiple colons) — take whole host; port is ambiguous without brackets.
+	if strings.Count(hostPart, ":") > 1 {
+		u.Host = hostPart
+		return nil
+	}
+
+	// IPv4 / hostname with optional :port
+	if i := strings.LastIndexByte(hostPart, ':'); i >= 0 {
+		port := hostPart[i+1:]
+		if port != "" && isDigits(port) {
+			u.Host = hostPart[:i]
+			u.Port = port
+			u.PortInt, _ = strconv.Atoi(port)
+			return nil
+		}
+	}
+
+	u.Host = hostPart
+	return nil
+}
+
+func isDigits(s string) bool {
+	for i := range s {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/sipparser/uri_test.go
+++ b/sipparser/uri_test.go
@@ -53,3 +53,49 @@ func TestUri(t *testing.T) {
 		t.Errorf("[TestUri] Error parsing URI \"sip:myfoo.com\".  Host should be \"myfoo.com\" but received: " + u.Host)
 	}
 }
+
+func TestUriIPv6Bracketed(t *testing.T) {
+	u := ParseURI("sip:+32460214964@[2a0c:10c0:ffff:2::1234]")
+	if u.Error != nil {
+		t.Fatalf("unexpected error: %v", u.Error)
+	}
+	if got, want := u.Host, "2a0c:10c0:ffff:2::1234"; got != want {
+		t.Fatalf("Host = %q, want %q", got, want)
+	}
+	if u.Port != "" {
+		t.Fatalf("Port = %q, want empty", u.Port)
+	}
+}
+
+func TestUriIPv6BracketedWithPort(t *testing.T) {
+	u := ParseURI("sip:user@[2001:db8::1]:5060")
+	if u.Error != nil {
+		t.Fatalf("unexpected error: %v", u.Error)
+	}
+	if got, want := u.Host, "2001:db8::1"; got != want {
+		t.Fatalf("Host = %q, want %q", got, want)
+	}
+	if got, want := u.Port, "5060"; got != want {
+		t.Fatalf("Port = %q, want %q", got, want)
+	}
+	if u.PortInt != 5060 {
+		t.Fatalf("PortInt = %d, want 5060", u.PortInt)
+	}
+}
+
+func TestUriIPv6Unbracketed(t *testing.T) {
+	u := ParseURI("sip:9876@fe80:0:0:0:21a:a0ff:fe07:32e0")
+	if u.Error != nil {
+		t.Fatalf("unexpected error: %v", u.Error)
+	}
+	if got, want := u.Host, "fe80:0:0:0:21a:a0ff:fe07:32e0"; got != want {
+		t.Fatalf("Host = %q, want %q", got, want)
+	}
+}
+
+func TestFromHeaderIPv6Domain(t *testing.T) {
+	s := ParseMsg("INVITE sip:a@b SIP/2.0\r\nFrom: \"+32460214964\" <sip:+32460214964@[2a0c:10c0:ffff:2::1234]>;tag=x\r\nTo: <sip:b@c>\r\nCall-ID: 1\r\nCSeq: 1 INVITE\r\n\r\n", nil, nil)
+	if got, want := s.FromHost, "2a0c:10c0:ffff:2::1234"; got != want {
+		t.Fatalf("FromHost = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- **#425**: fix SIP URI host parsing for IPv6 (`[addr]` and unbracketed multi-colon) so `from_domain` is complete
- **#539**: `PromTargetIP` accepts CIDR (e.g. `172.16.0.0/16`) and matches via `net.IPNet.Contains`
- **#463**: remove `DBWorker` clamp to `NumCPU` (safety max 256)
- Version **1.60.8**

Also closed as already fixed / out of scope: #556, #583, #578, #574.

## Test plan
- [x] `go test -vet=off ./sipparser/ ./metric/`
- [x] `go build ./...`
- [ ] Confirm `From: <sip:user@[2001:db8::1]>` stores full IPv6 in `from_domain`
- [ ] Confirm `PromTargetIP = "10.0.0.0/8"` tags matching sources
- [ ] Confirm `DBWorker = 32` on an 8-core host actually starts 32 inserters

Closes #425
Closes #539
Closes #463