### PR TITLE
fix: bytea raw storage (#540) and DB health metrics (#551)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ You have 3 options to get **heplify-server** up and running:
 ### Requirements
 These depend on which features you want to use and on whether you use homer5 or homer7 schema. For homer5, you need MySQL >= 5.7 or MariaDB >= 10. For homer7 you need PostgreSQL >= 10.
 
+Homer7 `raw` columns are stored as PostgreSQL `bytea` (binary-safe for SIP/ISUP multipart). Existing DBs are auto-migrated on startup when possible; if migration fails, run:
+
+```sql
+ALTER TABLE hep_proto_1_call ALTER COLUMN raw TYPE bytea USING convert_to(coalesce(raw::text, ''), 'UTF8');
+-- repeat for hep_proto_1_registration, hep_proto_1_default, hep_proto_5_default,
+-- hep_proto_35_default, hep_proto_53_default, hep_proto_54_default, hep_proto_100_default
+```
+
+DB health Prometheus metrics (when Prometheus is enabled): `heplify_db_up`, `heplify_db_insert_errors_total`, `heplify_db_insert_success_total`, `heplify_db_last_insert_success_timestamp_seconds`.
+
 ### Configuration
 **heplify-server** can be configured using command-line flags, environment variables, or a local [configuration file](https://github.com/sipcapture/heplify-server/blob/master/example/) or via web form by setting ConfigHTTPAddr  
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const Version = "heplify-server 1.60.8"
+const Version = "heplify-server 1.60.9"
 
 var Setting HeplifyServer
 

--- a/database/dbmetrics.go
+++ b/database/dbmetrics.go
@@ -1,0 +1,62 @@
+package database
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/negbie/logp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	dbUp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "heplify_db_up",
+		Help: "Whether the database is reachable (1=up, 0=down)",
+	}, []string{"driver"})
+
+	dbInsertErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "heplify_db_insert_errors_total",
+		Help: "Total database insert/bulk errors",
+	}, []string{"driver"})
+
+	dbInsertSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "heplify_db_insert_success_total",
+		Help: "Total successful database bulk inserts",
+	}, []string{"driver"})
+
+	dbLastSuccessUnix = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "heplify_db_last_insert_success_timestamp_seconds",
+		Help: "Unix timestamp of the last successful bulk insert",
+	}, []string{"driver"})
+)
+
+func startDBHealthMonitor(db *sql.DB, driver string) {
+	if db == nil {
+		return
+	}
+	dbUp.WithLabelValues(driver).Set(1)
+	go func() {
+		t := time.NewTicker(10 * time.Second)
+		defer t.Stop()
+		for range t.C {
+			if err := db.Ping(); err != nil {
+				dbUp.WithLabelValues(driver).Set(0)
+				logp.Err("db health check failed: %v", err)
+				continue
+			}
+			dbUp.WithLabelValues(driver).Set(1)
+		}
+	}()
+}
+
+func recordDBInsertError(driver string) {
+	dbInsertErrors.WithLabelValues(driver).Inc()
+	dbUp.WithLabelValues(driver).Set(0)
+}
+
+func recordDBInsertSuccess(driver string) {
+	dbInsertSuccess.WithLabelValues(driver).Inc()
+	dbLastSuccessUnix.WithLabelValues(driver).Set(float64(time.Now().Unix()))
+	dbUp.WithLabelValues(driver).Set(1)
+}

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -115,6 +115,8 @@ func (m *MySQL) setup() error {
 	m.sipBulkVal = sipQueryVal(m.bulkCnt)
 	m.rtcBulkVal = rtcQueryVal(m.bulkCnt)
 
+	startDBHealthMonitor(m.db, "mysql")
+
 	logp.Info("%s connection established\n", config.Setting.DBDriver)
 	return nil
 }
@@ -332,7 +334,10 @@ func (m *MySQL) bulkInsert(q, v []byte, rows []any) {
 	_, err := m.db.Exec(string(query), rows...)
 	if err != nil {
 		logp.Err("%v", err)
+		recordDBInsertError("mysql")
+		return
 	}
+	recordDBInsertSuccess("mysql")
 }
 
 func short(s string, i int) string {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -29,6 +29,17 @@ const (
 	logCopy      = "COPY hep_proto_100_default(sid,create_date,protocol_header,data_header,raw) FROM STDIN"
 )
 
+var pgRawTables = []string{
+	"hep_proto_1_call",
+	"hep_proto_1_registration",
+	"hep_proto_1_default",
+	"hep_proto_5_default",
+	"hep_proto_35_default",
+	"hep_proto_53_default",
+	"hep_proto_54_default",
+	"hep_proto_100_default",
+}
+
 func (p *Postgres) setup() error {
 	cs, err := ConnectString(config.Setting.DBDataTable)
 	if err != nil {
@@ -58,22 +69,49 @@ func (p *Postgres) setup() error {
 	}
 	p.dbTimer = time.Duration(config.Setting.DBTimer) * time.Second
 
+	p.ensureRawBytea()
+	startDBHealthMonitor(p.db, "postgres")
+
 	logp.Info("%s connection established\n", config.Setting.DBDriver)
 	return nil
+}
+
+// ensureRawBytea migrates existing varchar/text raw columns to bytea for binary-safe storage (#540).
+// New installs already get bytea from rotator schema. Best-effort; failures are logged only.
+func (p *Postgres) ensureRawBytea() {
+	for _, table := range pgRawTables {
+		var dataType string
+		err := p.db.QueryRow(`
+			SELECT data_type FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = $1 AND column_name = 'raw'`, table).Scan(&dataType)
+		if err != nil {
+			continue
+		}
+		if dataType == "bytea" {
+			continue
+		}
+		q := `ALTER TABLE ` + table + ` ALTER COLUMN raw TYPE bytea USING convert_to(coalesce(raw::text, ''), 'UTF8')`
+		if _, err := p.db.Exec(q); err != nil {
+			logp.Warn("could not migrate %s.raw to bytea (manual ALTER may be required): %v", table, err)
+			continue
+		}
+		logp.Info("migrated %s.raw to bytea", table)
+	}
 }
 
 func (p *Postgres) insert(hCh chan *decoder.HEP) {
 	var (
 		callCnt, regCnt, defCnt, dnsCnt, logCnt, rtcpCnt, isupCnt, reportCnt int
 
-		callRows   = make([]string, 0, p.bulkCnt)
-		regRows    = make([]string, 0, p.bulkCnt)
-		defRows    = make([]string, 0, p.bulkCnt)
-		dnsRows    = make([]string, 0, p.bulkCnt)
-		logRows    = make([]string, 0, p.bulkCnt)
-		isupRows   = make([]string, 0, p.bulkCnt)
-		rtcpRows   = make([]string, 0, p.bulkCnt)
-		reportRows = make([]string, 0, p.bulkCnt)
+		callRows   = make([]any, 0, p.bulkCnt*5)
+		regRows    = make([]any, 0, p.bulkCnt*5)
+		defRows    = make([]any, 0, p.bulkCnt*5)
+		dnsRows    = make([]any, 0, p.bulkCnt*5)
+		logRows    = make([]any, 0, p.bulkCnt*5)
+		isupRows   = make([]any, 0, p.bulkCnt*5)
+		rtcpRows   = make([]any, 0, p.bulkCnt*5)
+		reportRows = make([]any, 0, p.bulkCnt*5)
 		maxWait    = p.dbTimer
 	)
 
@@ -103,33 +141,34 @@ func (p *Postgres) insert(hCh chan *decoder.HEP) {
 			}
 
 			date := pkt.Timestamp.Format(time.RFC3339Nano)
+			raw := []byte(pkt.Payload)
 
 			if pkt.ProtoType == 1 && pkt.Payload != "" && pkt.SIP != nil {
 				pHeader := makeProtoHeader(pkt, bb)
 				dHeader := makeSIPDataHeader(pkt, bb, t)
 				switch pkt.SIP.Profile {
 				case "call":
-					callRows = append(callRows, pkt.SID, date, pHeader, dHeader, pkt.Payload)
+					callRows = append(callRows, pkt.SID, date, pHeader, dHeader, raw)
 					callCnt++
 					if callCnt == p.bulkCnt {
 						p.bulkInsert(callCopy, callRows)
-						callRows = []string{}
+						callRows = callRows[:0]
 						callCnt = 0
 					}
 				case "registration":
-					regRows = append(regRows, pkt.SID, date, pHeader, dHeader, pkt.Payload)
+					regRows = append(regRows, pkt.SID, date, pHeader, dHeader, raw)
 					regCnt++
 					if regCnt == p.bulkCnt {
 						p.bulkInsert(registerCopy, regRows)
-						regRows = []string{}
+						regRows = regRows[:0]
 						regCnt = 0
 					}
 				default:
-					defRows = append(defRows, pkt.SID, date, pHeader, dHeader, pkt.Payload)
+					defRows = append(defRows, pkt.SID, date, pHeader, dHeader, raw)
 					defCnt++
 					if defCnt == p.bulkCnt {
 						p.bulkInsert(defaultCopy, defRows)
-						defRows = []string{}
+						defRows = defRows[:0]
 						defCnt = 0
 					}
 				}
@@ -137,11 +176,11 @@ func (p *Postgres) insert(hCh chan *decoder.HEP) {
 				pHeader := makeProtoHeader(pkt, bb)
 				sid, dHeader := makeISUPDataHeader([]byte(pkt.Payload), bb)
 
-				isupRows = append(isupRows, sid, date, pHeader, dHeader, pkt.Payload)
+				isupRows = append(isupRows, sid, date, pHeader, dHeader, raw)
 				isupCnt++
 				if isupCnt == p.bulkCnt {
 					p.bulkInsert(isupCopy, isupRows)
-					isupRows = []string{}
+					isupRows = isupRows[:0]
 					isupCnt = 0
 				}
 
@@ -150,27 +189,27 @@ func (p *Postgres) insert(hCh chan *decoder.HEP) {
 				dHeader := makeRTCDataHeader(pkt, bb)
 				switch pkt.ProtoType {
 				case 5:
-					rtcpRows = append(rtcpRows, pkt.CID, date, pHeader, dHeader, pkt.Payload)
+					rtcpRows = append(rtcpRows, pkt.CID, date, pHeader, dHeader, raw)
 					rtcpCnt++
 					if rtcpCnt == p.bulkCnt {
 						p.bulkInsert(rtcpCopy, rtcpRows)
-						rtcpRows = []string{}
+						rtcpRows = rtcpRows[:0]
 						rtcpCnt = 0
 					}
 				case 53:
-					dnsRows = append(dnsRows, pkt.CID, date, pHeader, dHeader, pkt.Payload)
+					dnsRows = append(dnsRows, pkt.CID, date, pHeader, dHeader, raw)
 					dnsCnt++
 					if dnsCnt == p.bulkCnt {
 						p.bulkInsert(dnsCopy, dnsRows)
-						dnsRows = []string{}
+						dnsRows = dnsRows[:0]
 						dnsCnt = 0
 					}
 				case 100:
-					logRows = append(logRows, pkt.CID, date, pHeader, dHeader, pkt.Payload)
+					logRows = append(logRows, pkt.CID, date, pHeader, dHeader, raw)
 					logCnt++
 					if logCnt == p.bulkCnt {
 						p.bulkInsert(logCopy, logRows)
-						logRows = []string{}
+						logRows = logRows[:0]
 						logCnt = 0
 					}
 				default:
@@ -188,13 +227,13 @@ func (p *Postgres) insert(hCh chan *decoder.HEP) {
 					if ForcePayload {
 						reportRows = append(reportRows, pkt.CID, date, pHeader, pkt.Payload, dHeader)
 					} else {
-						reportRows = append(reportRows, pkt.CID, date, pHeader, dHeader, pkt.Payload)
+						reportRows = append(reportRows, pkt.CID, date, pHeader, dHeader, raw)
 					}
 
 					reportCnt++
 					if reportCnt == p.bulkCnt {
 						p.bulkInsert(reportCopy, reportRows)
-						reportRows = []string{}
+						reportRows = reportRows[:0]
 						reportCnt = 0
 					}
 				}
@@ -202,67 +241,61 @@ func (p *Postgres) insert(hCh chan *decoder.HEP) {
 		case <-timer.C:
 			timer.Reset(maxWait)
 			if callCnt > 0 {
-				l := len(callRows)
-				p.bulkInsert(callCopy, callRows[:l])
-				callRows = []string{}
+				p.bulkInsert(callCopy, callRows)
+				callRows = callRows[:0]
 				callCnt = 0
 			}
 			if regCnt > 0 {
-				l := len(regRows)
-				p.bulkInsert(registerCopy, regRows[:l])
-				regRows = []string{}
+				p.bulkInsert(registerCopy, regRows)
+				regRows = regRows[:0]
 				regCnt = 0
 			}
 			if defCnt > 0 {
-				l := len(defRows)
-				p.bulkInsert(defaultCopy, defRows[:l])
-				defRows = []string{}
+				p.bulkInsert(defaultCopy, defRows)
+				defRows = defRows[:0]
 				defCnt = 0
 			}
 			if rtcpCnt > 0 {
-				l := len(rtcpRows)
-				p.bulkInsert(rtcpCopy, rtcpRows[:l])
-				rtcpRows = []string{}
+				p.bulkInsert(rtcpCopy, rtcpRows)
+				rtcpRows = rtcpRows[:0]
 				rtcpCnt = 0
 			}
 			if reportCnt > 0 {
-				l := len(reportRows)
-				p.bulkInsert(reportCopy, reportRows[:l])
-				reportRows = []string{}
+				p.bulkInsert(reportCopy, reportRows)
+				reportRows = reportRows[:0]
 				reportCnt = 0
 			}
 			if dnsCnt > 0 {
-				l := len(dnsRows)
-				p.bulkInsert(dnsCopy, dnsRows[:l])
-				dnsRows = []string{}
+				p.bulkInsert(dnsCopy, dnsRows)
+				dnsRows = dnsRows[:0]
 				dnsCnt = 0
 			}
 			if logCnt > 0 {
-				l := len(logRows)
-				p.bulkInsert(logCopy, logRows[:l])
-				logRows = []string{}
+				p.bulkInsert(logCopy, logRows)
+				logRows = logRows[:0]
 				logCnt = 0
 			}
 			if isupCnt > 0 {
-				l := len(isupRows)
-				p.bulkInsert(isupCopy, isupRows[:l])
-				isupRows = []string{}
+				p.bulkInsert(isupCopy, isupRows)
+				isupRows = isupRows[:0]
 				isupCnt = 0
 			}
 		}
 	}
 }
 
-func (p *Postgres) bulkInsert(query string, rows []string) {
+func (p *Postgres) bulkInsert(query string, rows []any) {
 	tx, err := p.db.Begin()
 	if err != nil || tx == nil {
 		logp.Err("%v", err)
+		recordDBInsertError("postgres")
 		return
 	}
 
 	stmt, err := tx.Prepare(query)
 	if err != nil {
 		logp.Err("%v", err)
+		recordDBInsertError("postgres")
 		err := tx.Rollback()
 		if err != nil {
 			logp.Err("%v", err)
@@ -270,10 +303,12 @@ func (p *Postgres) bulkInsert(query string, rows []string) {
 		return
 	}
 
+	hadErr := false
 	for i := 0; i < len(rows); i = i + 5 {
 		_, err = stmt.Exec(rows[i], rows[i+1], rows[i+2], rows[i+3], rows[i+4])
 		if err != nil {
 			logp.Err("%v", err)
+			hadErr = true
 			continue
 		}
 	}
@@ -281,14 +316,23 @@ func (p *Postgres) bulkInsert(query string, rows []string) {
 	_, err = stmt.Exec()
 	if err != nil {
 		logp.Err("%v", err)
+		hadErr = true
 	}
 	err = stmt.Close()
 	if err != nil {
 		logp.Err("%v", err)
+		hadErr = true
 	}
 	err = tx.Commit()
 	if err != nil {
 		logp.Err("%v", err)
+		hadErr = true
+	}
+
+	if hadErr {
+		recordDBInsertError("postgres")
+	} else {
+		recordDBInsertSuccess("postgres")
 	}
 
 	logp.Debug("sql", "%s\n\n%v\n\n", query, rows)

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -188,7 +188,11 @@ func (h *HEP) normPayload() {
 		dedupCache.Set(kh, tb)
 	}
 
-	h.Payload = toUTF8(h.Payload, "")
+	// SIP (1) may carry multipart binary (e.g. ISUP); ISUP (54) is binary.
+	// Stripping NUL/invalid UTF-8 here corrupts payloads before DB storage (#540).
+	if h.ProtoType != 1 && h.ProtoType != 54 {
+		h.Payload = toUTF8(h.Payload, "")
+	}
 }
 
 func (h *HEP) EscapeFields(w io.Writer, tag string) (int, error) {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -160,3 +160,20 @@ func makeChunks(h *HEP) []byte {
 	}
 	return w.Bytes()
 }
+
+func TestNormPayloadPreservesSIPBinary(t *testing.T) {
+	// ISUP-like bytes including NUL and invalid UTF-8 sequences (#540).
+	bin := "SIP/2.0 200 OK\r\n\r\n" + string([]byte{0x01, 0x10, 0x48, 0x00, 0x0a, 0x87, 0xc0, 0xd0, 0xf5})
+	h := &HEP{ProtoType: 1, Payload: bin}
+	h.normPayload()
+	assert.Equal(t, bin, h.Payload)
+
+	h2 := &HEP{ProtoType: 54, Payload: bin}
+	h2.normPayload()
+	assert.Equal(t, bin, h2.Payload)
+
+	// Non-SIP still strips NUL / invalid UTF-8.
+	h3 := &HEP{ProtoType: 5, Payload: "ok\x00bad\xff"}
+	h3.normPayload()
+	assert.NotContains(t, h3.Payload, "\x00")
+}

--- a/rotator/pgfiles.go
+++ b/rotator/pgfiles.go
@@ -131,7 +131,7 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 
 	`CREATE TABLE IF NOT EXISTS hep_proto_35_default (
@@ -140,7 +140,7 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 
 	`CREATE TABLE IF NOT EXISTS hep_proto_5_default (
@@ -149,7 +149,7 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 
 	`CREATE TABLE IF NOT EXISTS hep_proto_1_call (
@@ -158,7 +158,7 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 
 	`CREATE TABLE IF NOT EXISTS hep_proto_1_registration (
@@ -167,7 +167,7 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 
 	`CREATE TABLE IF NOT EXISTS hep_proto_1_default (
@@ -176,7 +176,7 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 
 	`CREATE TABLE IF NOT EXISTS hep_proto_54_default (
@@ -185,6 +185,6 @@ var tbldatapg = []string{
 		create_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		protocol_header jsonb NOT NULL,
 		data_header jsonb NOT NULL,
-		raw varchar NOT NULL
+		raw bytea NOT NULL
 	) PARTITION BY RANGE (create_date);`,
 }


### PR DESCRIPTION
## Summary
- Store Homer7 `raw` as PostgreSQL `bytea` (schema + COPY `[]byte`) so SIP multipart/ISUP binary is not corrupted; skip UTF-8 stripping for SIP/ISUP payloads (#540)
- Best-effort startup migration of existing `varchar`/`text` `raw` columns to `bytea`
- Prometheus DB health metrics: `heplify_db_up`, insert success/error counters, last success timestamp (#551)
- Version bump to **1.60.9**

## Test plan
- [x] `go test ./decoder/ ./database/ ./remotelog/ ./server/ ./metric/`
- [ ] On a Homer7 PG instance: restart heplify-server, confirm `raw` is `bytea` and ISUP multipart round-trips
- [ ] Scrape Prometheus: `heplify_db_up{driver="postgres"} == 1` while DB is up; insert error counter increments when DB is down

Closes #540
Closes #551